### PR TITLE
Added PermutationUnaryOperator and PermutationBinaryOperator interfaces and related

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-02-17
+## [Unreleased] - 2022-03-17
 
 ### Added
 
@@ -19,6 +19,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### CI/CD
 
 ### Other
+
+
+## [3.2.0] - 2022-03-17
+
+### Added
+* PermutationUnaryOperator and PermutationBinaryOperator functional interfaces for the purpose
+  of specifying custom operations on Permutation objects.
+* Permutation.apply methods, one for each of the two new PermutationUnaryOperator 
+  and PermutationBinaryOperator interfaces, for applying such custom Permutation operators.
+
+### Changed
+* Various improvements to the documentation.
+
+### Deprecated
+* The Permutation.Mechanic nested class, which will be removed in the next 
+  major release 4.0.0. The new Permutation.apply methods should be used instead.
 
 
 ## [3.1.1] - 2022-02-17

--- a/src/main/java/org/cicirello/permutations/Permutation.java
+++ b/src/main/java/org/cicirello/permutations/Permutation.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005, 2010, 2014-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *

--- a/src/main/java/org/cicirello/permutations/Permutation.java
+++ b/src/main/java/org/cicirello/permutations/Permutation.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2005, 2010, 2014-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005, 2010, 2014-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -17,7 +18,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
 package org.cicirello.permutations;
 
@@ -37,8 +37,8 @@ import org.cicirello.util.Copyable;
  * This class provides the functionality to generate random permutations, and to
  * manipulate permutations in a variety of ways.
  * 
- * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
- * @version 3.31.2021
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
  */
 public final class Permutation implements Serializable, Iterable<Permutation>, Copyable<Permutation> {
 	
@@ -937,8 +937,8 @@ public final class Permutation implements Serializable, Iterable<Permutation>, C
 	 * a public method of Subclass can similarly, temporarily, create a non-functioning Permutation.  However,
 	 * that public method is expected to ensure that the Permutation is fully valid before returning.</p>
 	 *
-	 * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
-	 * @version 3.31.2021
+	 * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+	 * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
 	 */
 	public static class Mechanic {
 		

--- a/src/main/java/org/cicirello/permutations/Permutation.java
+++ b/src/main/java/org/cicirello/permutations/Permutation.java
@@ -44,6 +44,8 @@ public final class Permutation implements Serializable, Iterable<Permutation>, C
 	
 	private static final long serialVersionUID = 1L;
 	
+	private final int[] permutation;
+	
 	/**
 	 * Initializes a random permutation of n integers.  Uses
 	 * java.util.concurrent.ThreadLocalRandom as the source of efficient random number generation.
@@ -203,6 +205,15 @@ public final class Permutation implements Serializable, Iterable<Permutation>, C
 				}
 			}
 		}
+	}
+	
+	/**
+	 * Applies a custom unary operator on a Permutation object.
+	 *
+	 * @param operator A unary Permutation operator
+	 */
+	public void apply(PermutationUnaryOperator operator) {
+		operator.apply(permutation);
 	}
 	
 	/**
@@ -903,8 +914,6 @@ public final class Permutation implements Serializable, Iterable<Permutation>, C
 	public int hashCode() {
 		return Arrays.hashCode(permutation);
 	}
-	
-	private final int[] permutation;
 	
 	/**
 	 * <p>The Permutation.Mechanic class provides a means of adding application-specific

--- a/src/main/java/org/cicirello/permutations/Permutation.java
+++ b/src/main/java/org/cicirello/permutations/Permutation.java
@@ -217,6 +217,19 @@ public final class Permutation implements Serializable, Iterable<Permutation>, C
 	}
 	
 	/**
+	 * Applies a custom binary operator on a pair of Permutation objects.
+	 * The raw int array belonging to this is passed as the first array to
+	 * operator.apply() and the raw int array belonging to other is passed
+	 * as the second.
+	 *
+	 * @param operator A binary Permutation operator
+	 * @param other The other Permutation
+	 */
+	public void apply(PermutationBinaryOperator operator, Permutation other) {
+		operator.apply(permutation, other.permutation);
+	}
+	
+	/**
 	 * Creates an identical copy of this object.
 	 * @return an identical copy of this object
 	 */

--- a/src/main/java/org/cicirello/permutations/Permutation.java
+++ b/src/main/java/org/cicirello/permutations/Permutation.java
@@ -959,10 +959,15 @@ public final class Permutation implements Serializable, Iterable<Permutation>, C
 	 * a public method of Subclass can similarly, temporarily, create a non-functioning Permutation.  However,
 	 * that public method is expected to ensure that the Permutation is fully valid before returning.</p>
 	 *
+	 * @deprecated This class will be removed in the next major release, 4.0.0, and you should instead
+	 *    use the functionality provided by the {@link Permutation#apply(PermutationUnaryOperator)} and
+	 *    {@link Permutation#apply(PermutationBinaryOperator,Permutation)} methods, and the related
+	 *    {@link PermutationUnaryOperator} and {@link PermutationBinaryOperator} interfaces.
+	 *
 	 * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
 	 * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
 	 */
-	public static class Mechanic {
+	@Deprecated public static class Mechanic {
 		
 		/**
 		 * The default constructor can only be called by subclasses.

--- a/src/main/java/org/cicirello/permutations/PermutationBinaryOperator.java
+++ b/src/main/java/org/cicirello/permutations/PermutationBinaryOperator.java
@@ -1,0 +1,50 @@
+/*
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ *
+ * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ *
+ * JavaPermutationTools is free software: you can 
+ * redistribute it and/or modify it under the terms of the GNU 
+ * General Public License as published by the Free Software 
+ * Foundation, either version 3 of the License, or (at your 
+ * option) any later version.
+ *
+ * JavaPermutationTools is distributed in the hope 
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even 
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more 
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.cicirello.permutations;
+
+/**
+ * A functional interface for defining custom binary operators on Permutations.
+ * See the {@link Permutation#apply(PermutationBinaryOperator,Permutation)} method.
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
+ */
+@FunctionalInterface
+public interface PermutationBinaryOperator {
+	
+	/**
+	 * Applies an operator on the raw representations of
+	 * a pair of Permutations. Implementers of this interface are responsible
+	 * for ensuring that the apply method maintains valid
+	 * permutations of the integers in {0, 1, ..., rawPermutation1.length - 1 },
+	 * and likewise for rawPermutation2.
+	 *
+	 * @param rawPermutation1 A reference to the raw array of ints underlying a
+	 * Permutation object. Changes to this array will directly change the Permutation
+	 * object that encapsulates it.
+	 *
+	 * @param rawPermutation2 A reference to the raw array of ints underlying a
+	 * Permutation object. Changes to this array will directly change the Permutation
+	 * object that encapsulates it.
+	 */
+	void apply(int[] rawPermutation1, int[] rawPermutation2);
+}

--- a/src/main/java/org/cicirello/permutations/PermutationIterator.java
+++ b/src/main/java/org/cicirello/permutations/PermutationIterator.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2018-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -31,7 +32,8 @@ import java.util.NoSuchElementException;
  * of swaps it returns a copy (an O(n) operation) of the internally maintained Permutation object so the caller can safely
  * modify the returned Permutation without risk of interfering with the operation of the Iterator.
  *
- * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
  */
 public class PermutationIterator implements Iterator<Permutation> {
 	

--- a/src/main/java/org/cicirello/permutations/PermutationUnaryOperator.java
+++ b/src/main/java/org/cicirello/permutations/PermutationUnaryOperator.java
@@ -1,0 +1,45 @@
+/*
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ *
+ * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ *
+ * JavaPermutationTools is free software: you can 
+ * redistribute it and/or modify it under the terms of the GNU 
+ * General Public License as published by the Free Software 
+ * Foundation, either version 3 of the License, or (at your 
+ * option) any later version.
+ *
+ * JavaPermutationTools is distributed in the hope 
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even 
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more 
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.cicirello.permutations;
+
+/**
+ * A functional interface for defining custom unary operators on Permutations.
+ * See the {@link Permutation#apply(PermutationUnaryOperator)} method.
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
+ */
+@FunctionalInterface
+public interface PermutationUnaryOperator {
+	
+	/**
+	 * Applies an operator on the raw representation of
+	 * a Permutation. Implementers of this interface are responsible
+	 * for ensuring that the apply method maintains a valid
+	 * permutation of the integers in {0, 1, ..., rawPermutation.length - 1 }.
+	 *
+	 * @param rawPermutation A reference to the raw array of ints underlying a
+	 * Permutation object. Changes to this array will directly change the Permutation
+	 * object that encapsulates it.
+	 */
+	void apply(int[] rawPermutation);
+}

--- a/src/main/java/org/cicirello/permutations/distance/AcyclicEdgeDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/AcyclicEdgeDistance.java
@@ -1,7 +1,6 @@
 /*
- * Copyright 2014-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
- *
- * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ * JavaPermutationTools - A Java library for computation on permutations.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can 
  * redistribute it and/or modify it under the terms of the GNU 
@@ -17,13 +16,12 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.cicirello.permutations.distance;
 
 import org.cicirello.permutations.Permutation;
 /**
- * Acyclic Edge Distance:
- *
  * <p>Acyclic edge distance treats the permutations as if they represent sets of edges, and counts
  * the number of edges that differ.</p>
  *
@@ -41,8 +39,8 @@ import org.cicirello.permutations.Permutation;
  * <p>Acyclic edge distance was first described in:<br>
  * S. Ronald, "Distance functions for order-based encodings," in Proc. IEEE CEC. IEEE Press, 1997, pp. 49–54.</p>
  *
- * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
 public final class AcyclicEdgeDistance implements NormalizedPermutationDistanceMeasurer {
 	

--- a/src/main/java/org/cicirello/permutations/distance/BlockInterchangeDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/BlockInterchangeDistance.java
@@ -1,7 +1,6 @@
 /*
- * Copyright 2019, 2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
- *
- * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ * JavaPermutationTools - A Java library for computation on permutations.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can 
  * redistribute it and/or modify it under the terms of the GNU 
@@ -17,14 +16,13 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.cicirello.permutations.distance;
 
 import org.cicirello.permutations.Permutation;
 
 /**
- * Block Interchange Distance:
- *
  * <p>Block Interchange Distance is the minimum number of block interchanges 
  * necessary to transform one permutation into the other.  A block interchange is
  * an edit operation that takes two non-overlapping blocks (i.e., subsequence)
@@ -39,8 +37,8 @@ import org.cicirello.permutations.Permutation;
  *
  * <p>Runtime: O(n), where n is the permutation length.</p>
  *
- * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
 public class BlockInterchangeDistance implements NormalizedPermutationDistanceMeasurer {
 	

--- a/src/main/java/org/cicirello/permutations/distance/CyclicEdgeDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/CyclicEdgeDistance.java
@@ -1,7 +1,6 @@
 /*
- * Copyright 2014-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
- *
- * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ * JavaPermutationTools - A Java library for computation on permutations.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can 
  * redistribute it and/or modify it under the terms of the GNU 
@@ -17,13 +16,12 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.cicirello.permutations.distance;
 
 import org.cicirello.permutations.Permutation;
 /**
- * Cyclic Edge Distance:
- *
  * <p>Cyclic edge distance treats the permutations as if they represent sets of edges, and counts
  * the number of edges that differ.  It treats the last to the first element as an edge.</p>
  *
@@ -41,8 +39,8 @@ import org.cicirello.permutations.Permutation;
  * <p>Cyclic edge distance was first described in:<br>
  * S. Ronald, "Distance functions for order-based encodings," in Proc. IEEE CEC. IEEE Press, 1997, pp. 49–54.</p>
  *
- * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
 public final class CyclicEdgeDistance implements NormalizedPermutationDistanceMeasurer {
 	

--- a/src/main/java/org/cicirello/permutations/distance/CyclicIndependentDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/CyclicIndependentDistance.java
@@ -1,7 +1,6 @@
 /*
- * Copyright 2018-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
- *
- * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ * JavaPermutationTools - A Java library for computation on permutations.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can 
  * redistribute it and/or modify it under the terms of the GNU 
@@ -17,6 +16,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.cicirello.permutations.distance;
 
@@ -31,9 +31,8 @@ import org.cicirello.permutations.Permutation;
  * to rotations of p2, where the underlying distance measure is passed as a parameter to
  * the constructor.</p>
  *
- * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
- *  
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>  
  */
 public final class CyclicIndependentDistance implements PermutationDistanceMeasurer {
 	

--- a/src/main/java/org/cicirello/permutations/distance/CyclicIndependentDistanceDouble.java
+++ b/src/main/java/org/cicirello/permutations/distance/CyclicIndependentDistanceDouble.java
@@ -1,7 +1,6 @@
 /*
- * Copyright 2018-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
- *
- * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ * JavaPermutationTools - A Java library for computation on permutations.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can 
  * redistribute it and/or modify it under the terms of the GNU 
@@ -17,6 +16,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.cicirello.permutations.distance;
 
@@ -31,9 +31,8 @@ import org.cicirello.permutations.Permutation;
  * to rotations of p2, where the underlying distance measure is passed as a parameter to
  * the constructor.</p>
  *
- * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 1.28.2021
- *  
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
 public final class CyclicIndependentDistanceDouble implements PermutationDistanceMeasurerDouble {
 	

--- a/src/main/java/org/cicirello/permutations/distance/CyclicRTypeDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/CyclicRTypeDistance.java
@@ -1,7 +1,6 @@
 /*
- * Copyright 2010, 2014-2015, 2017-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
- *
- * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ * JavaPermutationTools - A Java library for computation on permutations.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can 
  * redistribute it and/or modify it under the terms of the GNU 
@@ -17,13 +16,12 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.cicirello.permutations.distance;
 
 import org.cicirello.permutations.Permutation;
 /**
- * Cyclic RType Distance:
- *
  * <p>Cyclic RType distance treats the permutations as if they represent sets of directed edges, and counts
  * the number of edges that differ.  It treats the last to the first element as an edge.</p>
  *
@@ -44,7 +42,6 @@ import org.cicirello.permutations.Permutation;
  * IEEE Transactions on Evolutionary Computation, 20(3):434-446, June 2016.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  */
 public final class CyclicRTypeDistance implements NormalizedPermutationDistanceMeasurer {
 	

--- a/src/main/java/org/cicirello/permutations/distance/CyclicReversalIndependentDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/CyclicReversalIndependentDistance.java
@@ -1,7 +1,6 @@
 /*
- * Copyright 2018-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
- *
- * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ * JavaPermutationTools - A Java library for computation on permutations.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can 
  * redistribute it and/or modify it under the terms of the GNU 
@@ -17,6 +16,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.cicirello.permutations.distance;
 
@@ -32,8 +32,8 @@ import org.cicirello.permutations.Permutation;
  * to rotations of p2 and rotations of the reverse of p2, where the underlying distance measure is passed as a parameter to
  * the constructor.</p>
  *
- * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  *  
  */
 public final class CyclicReversalIndependentDistance implements PermutationDistanceMeasurer {

--- a/src/main/java/org/cicirello/permutations/distance/CyclicReversalIndependentDistanceDouble.java
+++ b/src/main/java/org/cicirello/permutations/distance/CyclicReversalIndependentDistanceDouble.java
@@ -1,7 +1,6 @@
 /*
- * Copyright 2018-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
- *
- * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ * JavaPermutationTools - A Java library for computation on permutations.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can 
  * redistribute it and/or modify it under the terms of the GNU 
@@ -17,6 +16,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.cicirello.permutations.distance;
 
@@ -33,7 +33,6 @@ import org.cicirello.permutations.Permutation;
  * the constructor.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 1.28.2021
  *  
  */
 public final class CyclicReversalIndependentDistanceDouble implements PermutationDistanceMeasurerDouble {

--- a/src/main/java/org/cicirello/permutations/distance/DeviationDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/DeviationDistance.java
@@ -1,7 +1,6 @@
 /*
- * Copyright 2008, 2010, 2014, 2017-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
- *
- * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ * JavaPermutationTools - A Java library for computation on permutations.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can 
  * redistribute it and/or modify it under the terms of the GNU 
@@ -17,13 +16,12 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.cicirello.permutations.distance;
 
 import org.cicirello.permutations.Permutation;
 /**
- * Deviation Distance:
- *
  * <p>Deviation distance is the sum of the positional deviation of the permutation elements.
  * The positional deviation of an element is the difference in its location in the two
  * permutations.</p>
@@ -42,7 +40,6 @@ import org.cicirello.permutations.Permutation;
  * S. Ronald, "More distance functions for order-based encodings," in Proc. IEEE CEC. IEEE Press, 1998, pp. 558–563.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  * 
  */
 public final class DeviationDistance implements NormalizedPermutationDistanceMeasurer {

--- a/src/main/java/org/cicirello/permutations/distance/DeviationDistanceNormalized.java
+++ b/src/main/java/org/cicirello/permutations/distance/DeviationDistanceNormalized.java
@@ -1,7 +1,6 @@
 /*
- * Copyright 2014, 2017-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
- *
- * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ * JavaPermutationTools - A Java library for computation on permutations.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can 
  * redistribute it and/or modify it under the terms of the GNU 
@@ -17,14 +16,13 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.cicirello.permutations.distance;
 
 import org.cicirello.permutations.Permutation;
 
 /**
- * Normalized Deviation Distance:
- *
  * <p>Normalized Deviation distance is the sum of the positional deviation of the permutation elements
  * divided by N-1 (where N is the length of the permutation).
  * The positional deviation of an element is the difference in its location in the two
@@ -48,7 +46,6 @@ import org.cicirello.permutations.Permutation;
  * Proc. IEEE CEC. IEEE Press, 1998, pp. 558–563.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  * 
  */
 public final class DeviationDistanceNormalized implements NormalizedPermutationDistanceMeasurerDouble  {

--- a/src/main/java/org/cicirello/permutations/distance/DeviationDistanceNormalized2005.java
+++ b/src/main/java/org/cicirello/permutations/distance/DeviationDistanceNormalized2005.java
@@ -1,7 +1,6 @@
 /*
- * Copyright 2019-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
- *
- * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ * JavaPermutationTools - A Java library for computation on permutations.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can 
  * redistribute it and/or modify it under the terms of the GNU 
@@ -17,14 +16,13 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.cicirello.permutations.distance;
 
 import org.cicirello.permutations.Permutation;
 
 /**
- * Normalized Deviation Distance:
- *
  * <p>The original version of Normalized Deviation distance (Ronald, 1998) is the 
  * sum of the positional deviation of the permutation elements
  * divided by N-1 (where N is the length of the permutation).
@@ -62,7 +60,6 @@ import org.cicirello.permutations.Permutation;
  * management," in Proc. of MIC2005, 2005.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021  
  * 
  */
 public final class DeviationDistanceNormalized2005 implements NormalizedPermutationDistanceMeasurerDouble  {

--- a/src/main/java/org/cicirello/permutations/distance/EditDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/EditDistance.java
@@ -1,7 +1,6 @@
 /*
- * Copyright 2010, 2017-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
- *
- * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ * JavaPermutationTools - A Java library for computation on permutations.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can 
  * redistribute it and/or modify it under the terms of the GNU 
@@ -17,14 +16,13 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.cicirello.permutations.distance;
 
 
 import org.cicirello.permutations.Permutation;
 /**
- * Edit Distance:
- *
  * <p>This is an implementation of Wagner and Fischer's dynamic programming algorithm for computing string edit distance,
  * but adapted to permutations rather than general strings.</p>
  * 
@@ -53,7 +51,6 @@ import org.cicirello.permutations.Permutation;
  * in Proceedings of the 26th FLAIRS Conference. AAAI Press, May 2013, pp. 46–51.</p> 
  * 
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 1.28.2021
  */
 public final class EditDistance implements PermutationDistanceMeasurerDouble 
 {

--- a/src/main/java/org/cicirello/permutations/distance/ExactMatchDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/ExactMatchDistance.java
@@ -1,7 +1,6 @@
 /*
- * Copyright 2008, 2010, 2017-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
- *
- * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ * JavaPermutationTools - A Java library for computation on permutations.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can 
  * redistribute it and/or modify it under the terms of the GNU 
@@ -17,13 +16,12 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.cicirello.permutations.distance;
 
 import org.cicirello.permutations.Permutation;
 /**
- * Exact Match Distance:
- *
  * <p>Exact Match distance is an extension of Hamming distance but to non-binary strings, in this case, permutations.
  * It is the count of the number of positions for which the two permutations contain different elements.</p>
  *
@@ -33,7 +31,6 @@ import org.cicirello.permutations.Permutation;
  * S. Ronald, "More distance functions for order-based encodings," in Proc. IEEE CEC. IEEE Press, 1998, pp. 558–563.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  */
 public final class ExactMatchDistance implements NormalizedPermutationDistanceMeasurer {
   

--- a/src/main/java/org/cicirello/permutations/distance/InterchangeDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/InterchangeDistance.java
@@ -1,7 +1,6 @@
 /*
- * Copyright 2010, 2014, 2017-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
- *
- * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ * JavaPermutationTools - A Java library for computation on permutations.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can 
  * redistribute it and/or modify it under the terms of the GNU 
@@ -17,13 +16,12 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.cicirello.permutations.distance;
 
 import org.cicirello.permutations.Permutation;
 /**
- * Interchange Distance:
- *
  * <p>Interchange distance is the minimum number of swaps necessary to transform one
  * permutation into the other.</p>
  *
@@ -40,7 +38,6 @@ import org.cicirello.permutations.Permutation;
  * IEEE Transactions on Evolutionary Computation, 20(3):434-446, June 2016.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  */
 public final class InterchangeDistance implements NormalizedPermutationDistanceMeasurer {
 	

--- a/src/main/java/org/cicirello/permutations/distance/KendallTauDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/KendallTauDistance.java
@@ -1,8 +1,6 @@
 /*
- * JavaPermutationTools: A Java library for computation on permutations and sequences.
- * Copyright (C) 2014, 2015, 2017-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
- *
- * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ * JavaPermutationTools - A Java library for computation on permutations.
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can 
  * redistribute it and/or modify it under the terms of the GNU 
@@ -18,6 +16,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 package org.cicirello.permutations.distance;
 

--- a/src/main/java/org/cicirello/permutations/distance/LeeDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/LeeDistance.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2014, 2015, 2017-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -22,8 +23,6 @@ package org.cicirello.permutations.distance;
 
 import org.cicirello.permutations.Permutation;
 /**
- * Lee Distance:
- *
  * <p>Lee Distance is closely related to deviation distance.  However, Lee Distance considers the
  * permutation to be a cyclic structure when computing positional deviations.  That is, an element's
  * deviation between permutations is the minimum of its deviation to the right or to the left (wrapping
@@ -43,7 +42,6 @@ import org.cicirello.permutations.Permutation;
  * C. Lee, "Some properties of nonbinary error-correcting codes," in IRE Transactions on Information Theory, vol. 4, no. 2, pp. 77-82, June 1958.</p>
  * 
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  * 
  */
 public final class LeeDistance implements NormalizedPermutationDistanceMeasurer {

--- a/src/main/java/org/cicirello/permutations/distance/NormalizedPermutationDistanceMeasurer.java
+++ b/src/main/java/org/cicirello/permutations/distance/NormalizedPermutationDistanceMeasurer.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2019-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -27,7 +28,6 @@ import org.cicirello.permutations.Permutation;
  * normalizing the distance to the interval [0,1], but where the base distance is an integer value.
  * 
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  */
 public interface NormalizedPermutationDistanceMeasurer extends NormalizedPermutationDistanceMeasurerDouble, PermutationDistanceMeasurer {
 	

--- a/src/main/java/org/cicirello/permutations/distance/NormalizedPermutationDistanceMeasurerDouble.java
+++ b/src/main/java/org/cicirello/permutations/distance/NormalizedPermutationDistanceMeasurerDouble.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2019-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -27,7 +28,6 @@ import org.cicirello.permutations.Permutation;
  * normalizing the distance to the interval [0,1].
  * 
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  */
 public interface NormalizedPermutationDistanceMeasurerDouble extends PermutationDistanceMeasurerDouble {
 	

--- a/src/main/java/org/cicirello/permutations/distance/PermutationDistanceMeasurer.java
+++ b/src/main/java/org/cicirello/permutations/distance/PermutationDistanceMeasurer.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2010, 2017-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -26,7 +27,6 @@ import org.cicirello.permutations.Permutation;
  * Implement this interface, PermutationDistanceMeasurer, to define a distance metric for permutations.
  * 
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  */
 public interface PermutationDistanceMeasurer extends PermutationDistanceMeasurerDouble
 {

--- a/src/main/java/org/cicirello/permutations/distance/PermutationDistanceMeasurerDouble.java
+++ b/src/main/java/org/cicirello/permutations/distance/PermutationDistanceMeasurerDouble.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2010, 2017-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -27,7 +28,6 @@ import org.cicirello.permutations.Permutation;
  * where the distance is a floating-point value.
  * 
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 1.28.2021
  */
 public interface PermutationDistanceMeasurerDouble {
 	/**

--- a/src/main/java/org/cicirello/permutations/distance/RTypeDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/RTypeDistance.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2010, 2014, 2017-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -22,9 +23,7 @@ package org.cicirello.permutations.distance;
 
 
 import org.cicirello.permutations.Permutation;
- /**
- * RType Distance:
- *
+/**
  * <p>RType distance treats the permutations as if they represent sets of directed edges, and counts
  * the number of edges that differ.</p>
  *
@@ -44,7 +43,6 @@ import org.cicirello.permutations.Permutation;
  * INFORMS Journal on Computing, vol. 17, no. 1, pp. 111–122, 2005.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  */
 public final class RTypeDistance implements NormalizedPermutationDistanceMeasurer {
 	

--- a/src/main/java/org/cicirello/permutations/distance/ReinsertionDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/ReinsertionDistance.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2015, 2017-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -22,8 +23,6 @@ package org.cicirello.permutations.distance;
 
 import org.cicirello.permutations.Permutation;
 /**
- * Reinsertion Distance:
- *
  * <p>Reinsertion distance is the count of the number of removal/reinsertion operations
  * needed to transform one permutation into the other.</p>
  * 
@@ -57,7 +56,6 @@ import org.cicirello.permutations.Permutation;
  * Communications of the ACM, 20(5):350-353, May, 1977.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  *
  */
 public final class ReinsertionDistance implements NormalizedPermutationDistanceMeasurer {

--- a/src/main/java/org/cicirello/permutations/distance/ReversalDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/ReversalDistance.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2015-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -24,8 +25,6 @@ import org.cicirello.permutations.Permutation;
 import java.util.Arrays;
 
 /**
-* Reversal Distance:
-*
 * <p>Reversal Distance is the minimum number of subpermutation reversals necessary to transform one
 * permutation into the other.  This is an NP-Hard problem.</p>
 *
@@ -48,7 +47,6 @@ import java.util.Arrays;
 * <p>We have not used this for N &gt; 10.  Warning: time to construct distance measure increases factorially.</p>
 *
 * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
-* @version 5.13.2021
 */
 public final class ReversalDistance implements NormalizedPermutationDistanceMeasurer {
 

--- a/src/main/java/org/cicirello/permutations/distance/ReversalIndependentDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/ReversalIndependentDistance.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2018-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -32,7 +33,6 @@ import org.cicirello.permutations.Permutation;
  * to the constructor.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  *  
  */
 public final class ReversalIndependentDistance implements PermutationDistanceMeasurer {

--- a/src/main/java/org/cicirello/permutations/distance/ReversalIndependentDistanceDouble.java
+++ b/src/main/java/org/cicirello/permutations/distance/ReversalIndependentDistanceDouble.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2018-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -32,7 +33,6 @@ import org.cicirello.permutations.Permutation;
  * to the constructor.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 1.28.2021
  *  
  */
 public final class ReversalIndependentDistanceDouble implements PermutationDistanceMeasurerDouble {

--- a/src/main/java/org/cicirello/permutations/distance/ScrambleDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/ScrambleDistance.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2016-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -22,8 +23,6 @@ package org.cicirello.permutations.distance;
 
 import org.cicirello.permutations.Permutation;
 /**
- * Scramble Distance:
- *
  * <p>Scramble Distance is the minimum number of random shufflings needed to transform one permutation into the other.
  * This was implemented for a very specific purpose, and unlikely to be subsequently useful.</p>
  *
@@ -32,7 +31,6 @@ import org.cicirello.permutations.Permutation;
  * <p>Runtime: O(n), where n is the permutation length.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  */
 public final class ScrambleDistance implements NormalizedPermutationDistanceMeasurer {
 	

--- a/src/main/java/org/cicirello/permutations/distance/SquaredDeviationDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/SquaredDeviationDistance.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2014, 2015, 2017-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -23,8 +24,6 @@ package org.cicirello.permutations.distance;
 import org.cicirello.permutations.Permutation;
 
 /**
- * Squared Deviation Distance:
- *
  * <p>Squared Deviation distance is the sum of the squares of the positional deviations of the permutation elements.
  * The positional deviation of an element is the difference in its location in the two
  * permutations.</p>
@@ -44,8 +43,6 @@ import org.cicirello.permutations.Permutation;
  * The 6th Metaheuristics International Conference, August, 2005.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
- * 
  */
 public final class SquaredDeviationDistance implements NormalizedPermutationDistanceMeasurer {
 	

--- a/src/main/java/org/cicirello/permutations/distance/package-info.java
+++ b/src/main/java/org/cicirello/permutations/distance/package-info.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2008, 2010, 2014-2018 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -19,9 +20,10 @@
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
  */
  
- /**
+/**
  * Implementations of a variety of permutation distance measures. 
- * @version 1.18.7.17
- * @since 1.0
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
 package org.cicirello.permutations.distance;

--- a/src/main/java/org/cicirello/permutations/package-info.java
+++ b/src/main/java/org/cicirello/permutations/package-info.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2005, 2010, 2014-2018 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -17,12 +18,12 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
  
- /**
- * Collection of classes related to representing and manipulating permutations. 
- * @version 1.18.5.30
- * @since 1.0
+/**
+ * Collection of classes related to representing and manipulating permutations.
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
 package org.cicirello.permutations;

--- a/src/main/java/org/cicirello/sequences/SequenceSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceSampler.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2019-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -17,9 +18,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
- 
+ */ 
 package org.cicirello.sequences;
 
 import org.cicirello.math.rand.RandomIndexer;
@@ -32,7 +31,6 @@ import java.util.Arrays;
  * efficiently generating random samples of array elements, without replacement.
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
- * @version 5.24.2021
  */
 public final class SequenceSampler {
 	

--- a/src/main/java/org/cicirello/sequences/distance/EditDistance.java
+++ b/src/main/java/org/cicirello/sequences/distance/EditDistance.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2018-2019, 2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -52,7 +53,6 @@ import java.util.List;
  * R. A. Wagner and M. J. Fischer, "The string-to-string correction problem," Journal of the ACM, vol. 21, no. 1, pp. 168–173, January 1974.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  */
 public class EditDistance implements SequenceDistanceMeasurer {
 	

--- a/src/main/java/org/cicirello/sequences/distance/ExactMatchDistance.java
+++ b/src/main/java/org/cicirello/sequences/distance/ExactMatchDistance.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2018-2019, 2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -44,7 +45,6 @@ import java.util.Iterator;
  * S. Ronald, "More distance functions for order-based encodings," in Proc. IEEE CEC. IEEE Press, 1998, pp. 558–563.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  */
 public final class ExactMatchDistance implements SequenceDistanceMeasurer {
 	

--- a/src/main/java/org/cicirello/sequences/distance/KendallTauSequenceDistance.java
+++ b/src/main/java/org/cicirello/sequences/distance/KendallTauSequenceDistance.java
@@ -1,6 +1,6 @@
 /*
- * JavaPermutationTools: A Java library for computation on permutations and sequences.
- * Copyright (C) 2018-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *

--- a/src/main/java/org/cicirello/sequences/distance/LongestCommonSubsequenceDistance.java
+++ b/src/main/java/org/cicirello/sequences/distance/LongestCommonSubsequenceDistance.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2018-2019, 2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -46,7 +47,6 @@ package org.cicirello.sequences.distance;
  * R. A. Wagner and M. J. Fischer, "The string-to-string correction problem," Journal of the ACM, vol. 21, no. 1, pp. 168–173, January 1974.</p>
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  */
 public final class LongestCommonSubsequenceDistance extends EditDistance {
 	

--- a/src/main/java/org/cicirello/sequences/distance/SequenceDistanceMeasurer.java
+++ b/src/main/java/org/cicirello/sequences/distance/SequenceDistanceMeasurer.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2018-2019, 2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -46,7 +47,6 @@ import java.util.List;
  * permutations of the integers from 0 to N-1.</p>
  * 
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
  */
 public interface SequenceDistanceMeasurer extends SequenceDistanceMeasurerDouble {
 	

--- a/src/main/java/org/cicirello/sequences/distance/SequenceDistanceMeasurerDouble.java
+++ b/src/main/java/org/cicirello/sequences/distance/SequenceDistanceMeasurerDouble.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2018-2019, 2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -23,17 +24,24 @@ package org.cicirello.sequences.distance;
 import java.util.List;
 
 /**
- * <p>Implement this interface, SequenceDistanceMeasurerDouble, to define a distance metric for sequences.  A sequence may have duplicate elements, unlike
- * a Permutation which must have unique elements.  Some SequenceDistanceMeasurers may require the pair of sequences to be the same length, while
- * others do not have that requirement.  Some SequenceDistanceMeasurers may require the pair of sequences to contain the same set of elements, while
- * others do not have that requirement.  Implementations of this interface compute distances that are floating-point valued.</p>
+ * <p>Implement this interface, SequenceDistanceMeasurerDouble, to define 
+ * a distance metric for sequences.  A sequence may have duplicate elements, unlike
+ * a Permutation which must have unique elements.  Some SequenceDistanceMeasurers 
+ * may require the pair of sequences to be the same length, while
+ * others do not have that requirement.  Some SequenceDistanceMeasurers may 
+ * require the pair of sequences to contain the same set of elements, while
+ * others do not have that requirement.  Implementations of this interface 
+ * compute distances that are floating-point valued.</p>
  *
- * <p>If your sequences are guaranteed not to contain duplicates, and the pair is guaranteed to contain the same set of elements, and are of the same length,
- * then consider instead using the classes that implement the {@link org.cicirello.permutations.distance.PermutationDistanceMeasurerDouble PermutationDistanceMeasurerDouble}
- * interface.  Those classes are specifically for distance between permutations of the integers from 0 to N-1.</p>
+ * <p>If your sequences are guaranteed not to contain duplicates, and the pair 
+ * is guaranteed to contain the same set of elements, and are of the same length,
+ * then consider instead using the classes that implement 
+ * the {@link org.cicirello.permutations.distance.PermutationDistanceMeasurerDouble PermutationDistanceMeasurerDouble}
+ * interface.  Those classes are specifically for distance between 
+ * permutations of the integers from 0 to N-1.</p>
  * 
- * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
- * @version 4.2.2021
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
 public interface SequenceDistanceMeasurerDouble {
 	

--- a/src/main/java/org/cicirello/sequences/distance/package-info.java
+++ b/src/main/java/org/cicirello/sequences/distance/package-info.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2018-2021 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -17,11 +18,13 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
  
- /**
- * Implementations of distance measures for general sequences of various forms, including Strings, arrays of primitive types, arrays of objects, etc. 
- * @version 5.24.2021
+/**
+ * Implementations of distance measures for general sequences of various forms, 
+ * including Strings, arrays of primitive types, arrays of objects, etc. 
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
 package org.cicirello.sequences.distance;

--- a/src/main/java/org/cicirello/sequences/package-info.java
+++ b/src/main/java/org/cicirello/sequences/package-info.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2019 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -17,12 +18,12 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
  
- /**
- * Classes that perform a variety of operations on sequences (such as arrays, etc). 
- * @version 1.19.6.7
- * @since 1.5
+/**
+ * Classes that perform a variety of operations on sequences (such as arrays, etc).
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
  */
 package org.cicirello.sequences;

--- a/src/test/java/org/cicirello/permutations/PermutationTestCases.java
+++ b/src/test/java/org/cicirello/permutations/PermutationTestCases.java
@@ -44,6 +44,35 @@ public class PermutationTestCases {
 	private static final boolean disableChiSquareTests = true;
 	
 	@Test
+	public void testUnaryOperator() {
+		Permutation p = new Permutation(10);
+		p.apply(perm -> { for (int i = 0; i < perm.length; i++) { perm[i] = i; }});
+		for (int i = 0; i < 10; i++) {
+			assertEquals(i, p.get(i));
+		}
+		p.apply(perm -> { for (int i = 0; i < perm.length; i++) { perm[perm.length-1-i] = i; }});
+		for (int i = 0; i < 10; i++) {
+			assertEquals(9-i, p.get(i));
+		}
+	}
+	
+	@Test
+	public void testBinaryOperator() {
+		Permutation p1 = new Permutation(10);
+		Permutation p2 = new Permutation(10);
+		p1.apply((perm1, perm2) -> { for (int i = 0; i < perm1.length; i++) { perm1[i] = i; perm2[perm1.length-1-i] = i; }}, p2);
+		for (int i = 0; i < 10; i++) {
+			assertEquals(i, p1.get(i));
+			assertEquals(9-i, p2.get(i));
+		}
+		p1.apply((perm1, perm2) -> { for (int i = 0; i < perm1.length; i++) { perm2[i] = i; perm1[perm1.length-1-i] = i; }}, p2);
+		for (int i = 0; i < 10; i++) {
+			assertEquals(i, p2.get(i));
+			assertEquals(9-i, p1.get(i));
+		}
+	}
+	
+	@Test
 	public void testZeroLengthPermutations() {
 		// different ways of constructing 0 length permutations.
 		Permutation p1 = new Permutation(0);		

--- a/src/test/java/org/cicirello/permutations/PermutationTestCases.java
+++ b/src/test/java/org/cicirello/permutations/PermutationTestCases.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2018-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -227,8 +228,7 @@ public class PermutationTestCases {
 		);
 	}
 	
-	@Test
-	public void testPermutationMechanicSet() {
+	@Test @SuppressWarnings("deprecation") public void testPermutationMechanicSet() {
 		
 		class MyMech extends Permutation.Mechanic {
 			public void testSet(Permutation p, int[] a) {


### PR DESCRIPTION
## Summary
This PR contains the following:

### Added
* PermutationUnaryOperator and PermutationBinaryOperator functional interfaces for the purpose
  of specifying custom operations on Permutation objects.
* Permutation.apply methods, one for each of the two new PermutationUnaryOperator 
  and PermutationBinaryOperator interfaces, for applying such custom Permutation operators.

### Changed
* Various improvements to the documentation.

### Deprecated
* The Permutation.Mechanic nested class, which will be removed in the next 
  major release 4.0.0. The new Permutation.apply methods should be used instead.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
