### PR TITLE
Fix ReversalDistance.max in the general case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-03-17
+## [Unreleased] - 2022-04-16
 
 ### Added
 
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+* ReversalDistance.max method now handles general case properly.
 
 ### CI/CD
 

--- a/src/main/java/org/cicirello/permutations/distance/ReversalDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/ReversalDistance.java
@@ -52,8 +52,7 @@ public final class ReversalDistance implements NormalizedPermutationDistanceMeas
 
 	private byte[] dist;
 	private final int PERM_LENGTH;
-	private int maxd;
-
+	
 	/**
 	 * Construct the distance measure. Default handles permutations of length n=5.
 	 */
@@ -71,7 +70,6 @@ public final class ReversalDistance implements NormalizedPermutationDistanceMeas
 		if (n > 12 || n < 0) throw new IllegalArgumentException("Requires 0 <= n <= 12.");
 		PERM_LENGTH = n;
 		int fact = 1;
-		maxd = 0;
 		for (int i = 2; i <= n; i++) fact *= i;
 		dist = new byte[fact];
 		final byte BYTE_MAX = 0x7f;
@@ -83,7 +81,6 @@ public final class ReversalDistance implements NormalizedPermutationDistanceMeas
 				int v = p.toInteger();
 				p.reverse(i,j);
 				dist[v] = 1;
-				maxd = 1;
 			}
 		}
 		int visited = n * (n-1) / 2 + 1;
@@ -99,7 +96,7 @@ public final class ReversalDistance implements NormalizedPermutationDistanceMeas
 							int v = p.toInteger();
 							p.reverse(i,j);
 							if (v > 0 && dist[v]==BYTE_MAX) {
-								maxd = dist[v] = (byte)(d + 1);
+								dist[v] = (byte)(d + 1);
 								visited++;
 							}
 						}
@@ -129,19 +126,13 @@ public final class ReversalDistance implements NormalizedPermutationDistanceMeas
 		return dist[new Permutation(r2).toInteger()];
 	}	
 	
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @throws IllegalArgumentException if length is not equal to the
-	 * the permutation length for which this was configured at time
-	 * of construction.
-	 */
 	@Override
 	public int max(int length) {
-		if (PERM_LENGTH != length) {
-			throw new IllegalArgumentException("This distance measurer was not configured for length: " + length);
+		if (length > 1) {
+			return length - 1;
+		} else {
+			return 0;
 		}
-		return maxd;
 	}
 	
 }

--- a/src/main/java/org/cicirello/permutations/distance/ReversalDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/ReversalDistance.java
@@ -129,6 +129,9 @@ public final class ReversalDistance implements NormalizedPermutationDistanceMeas
 	@Override
 	public int max(int length) {
 		if (length > 1) {
+			// Source: Bafna, V.; Pevzner, P.A. Genome Rearrangements and Sorting 
+			// by Reversals. SIAM Journal on Computing 1996, 25, 272–289. 570
+			// doi:10.1137/S0097539793250627.
 			return length - 1;
 		} else {
 			return 0;

--- a/src/test/java/org/cicirello/permutations/distance/PermutationDistanceMaxTests.java
+++ b/src/test/java/org/cicirello/permutations/distance/PermutationDistanceMaxTests.java
@@ -43,12 +43,6 @@ public class PermutationDistanceMaxTests {
 		assertEquals(2, d.max(3));
 		d = new ReversalDistance(4);
 		assertEquals(3, d.max(4));
-		
-		final ReversalDistance df = d;
-		IllegalArgumentException thrown = assertThrows( 
-			IllegalArgumentException.class,
-			() -> df.max(7)
-		);
 	}
 	
 	@Test


### PR DESCRIPTION
## Summary
Fix ReversalDistance.max in the general case, based on proof found in Bafna, V and Pevzner, P.A. Genome Rearrangements and Sorting by Reversals. SIAM Journal on Computing 1996,

## Closing Issues
Closes #200 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
