### PR TITLE
Added applyThenValidate methods to Permutation class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-08-03
+## [Unreleased] - 2022-08-25
 
 ### Added
+* Four Permutation.applyThenValidate methods, which are counterparts to the four Permutation.apply method 
+  but which validate the Permutation(s) that result from the applied operator; whereas the existing apply
+  methods do not verify the state of the Permutation after operator application.
+* IllegalPermutationStateException exception class that is thrown by the new Permutation.applyThenValidate 
+  methods if validation fails.
 
 ### Changed
 

--- a/src/main/java/org/cicirello/permutations/IllegalPermutationStateException.java
+++ b/src/main/java/org/cicirello/permutations/IllegalPermutationStateException.java
@@ -1,0 +1,52 @@
+/*
+ * JavaPermutationTools: A Java library for computation on permutations and sequences
+ * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ *
+ * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
+ *
+ * JavaPermutationTools is free software: you can 
+ * redistribute it and/or modify it under the terms of the GNU 
+ * General Public License as published by the Free Software 
+ * Foundation, either version 3 of the License, or (at your 
+ * option) any later version.
+ *
+ * JavaPermutationTools is distributed in the hope 
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even 
+ * the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * PARTICULAR PURPOSE.  See the GNU General Public License for more 
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with JavaPermutationTools.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.cicirello.permutations;
+
+/**
+ * This is a {@link RuntimeException} that is thrown by certain methods of the {@link Permutation}
+ * class to indicate that the Permutation object's state is invalid, and any subsequent calls
+ * to methods on that object may be unpredictable.
+ *
+ * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, 
+ * <a href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a> 
+ */
+public class IllegalPermutationStateException extends RuntimeException {
+	
+	/**
+	 * Construct an IllegalPermutationStateException without specifying a cause.
+	 *
+	 * @param message A descriptive message about the exception that is thrown.
+	 */
+	public IllegalPermutationStateException(String message) {
+		super(message);
+	}
+	
+	/**
+	 * Construct an IllegalPermutationStateException.
+	 *
+	 * @param message A descriptive message about the exception that is thrown.
+	 * @param cause The cause of the exception.
+	 */
+	public IllegalPermutationStateException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/src/test/java/org/cicirello/permutations/PermutationTestCases.java
+++ b/src/test/java/org/cicirello/permutations/PermutationTestCases.java
@@ -44,6 +44,19 @@ public class PermutationTestCases {
 	private static final boolean disableChiSquareTests = true;
 	
 	@Test
+	public void testIllegalPermutationStateExceptionConstructors() {
+		IllegalPermutationStateException e1 = new IllegalPermutationStateException("test message");
+		assertEquals("test message", e1.getMessage());
+		assertNull(e1.getCause());
+		e1 = new IllegalPermutationStateException("test message", new IllegalArgumentException());
+		assertEquals("test message", e1.getMessage());
+		assertTrue(e1.getCause() instanceof IllegalArgumentException);
+		e1 = new IllegalPermutationStateException("test message", new IllegalPermutationStateException("testing 1 2 3"));
+		assertEquals("test message", e1.getMessage());
+		assertTrue(e1.getCause() instanceof IllegalPermutationStateException);
+	}
+	
+	@Test
 	public void testUnaryOperator() {
 		Permutation p = new Permutation(10);
 		p.apply(perm -> { for (int i = 0; i < perm.length; i++) { perm[i] = i; }});
@@ -54,6 +67,24 @@ public class PermutationTestCases {
 		for (int i = 0; i < 10; i++) {
 			assertEquals(9-i, p.get(i));
 		}
+	}
+	
+	@Test
+	public void testValidatedUnaryOperator() {
+		final Permutation p = new Permutation(10);
+		p.applyThenValidate(perm -> { for (int i = 0; i < perm.length; i++) { perm[i] = i; }});
+		for (int i = 0; i < 10; i++) {
+			assertEquals(i, p.get(i));
+		}
+		p.applyThenValidate(perm -> { for (int i = 0; i < perm.length; i++) { perm[perm.length-1-i] = i; }});
+		for (int i = 0; i < 10; i++) {
+			assertEquals(9-i, p.get(i));
+		}
+		IllegalPermutationStateException thrown = assertThrows( 
+			IllegalPermutationStateException.class,
+			() -> p.applyThenValidate(perm -> { for (int i = 0; i < perm.length; i++) { perm[i] = 0; }})
+		);
+		assertTrue(thrown.getCause() instanceof IllegalArgumentException);
 	}
 	
 	@Test
@@ -73,6 +104,27 @@ public class PermutationTestCases {
 	}
 	
 	@Test
+	public void testValidatedBinaryOperator() {
+		final Permutation p1 = new Permutation(10);
+		final Permutation p2 = new Permutation(10);
+		p1.applyThenValidate((perm1, perm2) -> { for (int i = 0; i < perm1.length; i++) { perm1[i] = i; perm2[perm1.length-1-i] = i; }}, p2);
+		for (int i = 0; i < 10; i++) {
+			assertEquals(i, p1.get(i));
+			assertEquals(9-i, p2.get(i));
+		}
+		p1.applyThenValidate((perm1, perm2) -> { for (int i = 0; i < perm1.length; i++) { perm2[i] = i; perm1[perm1.length-1-i] = i; }}, p2);
+		for (int i = 0; i < 10; i++) {
+			assertEquals(i, p2.get(i));
+			assertEquals(9-i, p1.get(i));
+		}
+		IllegalPermutationStateException thrown = assertThrows( 
+			IllegalPermutationStateException.class,
+			() -> p1.applyThenValidate((perm1, perm2) -> { for (int i = 0; i < perm1.length; i++) { perm1[i] = 0; perm2[perm1.length-1-i] = 0; }}, p2)
+		);
+		assertTrue(thrown.getCause() instanceof IllegalArgumentException);
+	}
+	
+	@Test
 	public void testFullUnaryOperator() {
 		Permutation p = new Permutation(10);
 		p.apply((perm, original) -> { for (int i = 0; i < perm.length; i++) { perm[i] = i; assertEquals(perm[i], original.get(i)); }});
@@ -83,6 +135,24 @@ public class PermutationTestCases {
 		for (int i = 0; i < 10; i++) {
 			assertEquals(9-i, p.get(i));
 		}
+	}
+	
+	@Test
+	public void testValidatedFullUnaryOperator() {
+		final Permutation p = new Permutation(10);
+		p.applyThenValidate((perm, original) -> { for (int i = 0; i < perm.length; i++) { perm[i] = i; assertEquals(perm[i], original.get(i)); }});
+		for (int i = 0; i < 10; i++) {
+			assertEquals(i, p.get(i));
+		}
+		p.applyThenValidate((perm, original) -> { for (int i = 0; i < perm.length; i++) { perm[perm.length-1-i] = i; assertEquals(perm[perm.length-1-i], original.get(perm.length-1-i)); }});
+		for (int i = 0; i < 10; i++) {
+			assertEquals(9-i, p.get(i));
+		}
+		IllegalPermutationStateException thrown = assertThrows( 
+			IllegalPermutationStateException.class,
+			() -> p.applyThenValidate((perm, original) -> { for (int i = 0; i < perm.length; i++) { perm[i] = 0; }})
+		);
+		assertTrue(thrown.getCause() instanceof IllegalArgumentException);
 	}
 	
 	@Test
@@ -99,6 +169,27 @@ public class PermutationTestCases {
 			assertEquals(i, p2.get(i));
 			assertEquals(9-i, p1.get(i));
 		}
+	}
+	
+	@Test
+	public void testValidatedFullBinaryOperator() {
+		final Permutation p1 = new Permutation(10);
+		final Permutation p2 = new Permutation(10);
+		p1.applyThenValidate((perm1, perm2, o1, o2) -> { for (int i = 0; i < perm1.length; i++) { perm1[i] = i; perm2[perm1.length-1-i] = i; assertEquals(i, o1.get(i)); assertEquals(i, o2.get(9-i)); }}, p2);
+		for (int i = 0; i < 10; i++) {
+			assertEquals(i, p1.get(i));
+			assertEquals(9-i, p2.get(i));
+		}
+		p1.applyThenValidate((perm1, perm2, o1, o2) -> { for (int i = 0; i < perm1.length; i++) { perm2[i] = i; perm1[perm1.length-1-i] = i; assertEquals(i, o2.get(i)); assertEquals(i, o1.get(9-i)); }}, p2);
+		for (int i = 0; i < 10; i++) {
+			assertEquals(i, p2.get(i));
+			assertEquals(9-i, p1.get(i));
+		}
+		IllegalPermutationStateException thrown = assertThrows( 
+			IllegalPermutationStateException.class,
+			() -> p1.applyThenValidate((perm1, perm2, o1, o2) -> { for (int i = 0; i < perm1.length; i++) { perm1[i] = 0; perm2[perm1.length-1-i] = 0; }}, p2)
+		);
+		assertTrue(thrown.getCause() instanceof IllegalArgumentException);
 	}
 	
 	@Test


### PR DESCRIPTION
## Summary

Added:
* Four Permutation.applyThenValidate methods, which are counterparts to the four Permutation.apply method 
  but which validate the Permutation(s) that result from the applied operator; whereas the existing apply
  methods do not verify the state of the Permutation after operator application.
* IllegalPermutationStateException exception class that is thrown by the new Permutation.applyThenValidate 
  methods if validation fails.
## Closing Issues
Closes #234 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
