### PR TITLE
Minor edit to pom.xml to use a SNAPSHOT version number for local builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
  
 	<groupId>org.cicirello</groupId>
 	<artifactId>jpt</artifactId>
-	<version>4.0.0</version>
+	<version>4-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>JavaPermutationTools</name>


### PR DESCRIPTION
## Summary
Our CI/CD workflows injects the real version number at the time artifacts are published to Maven Central, etc. The pom.xml had a specific prior version number hardcoded, which may cause confusion if someone builds locally (e.g., may mistakenly think they have an older specific version). Changed the version attribute in the pom.xml to 4-SNAPSHOT so locally built artifacts that are built directly from the current state of the default branch will be clearly identified as a SNAPSHOT.
