### PR TITLE
Updated .lift.toml to simplify configuration rules for Sonatype Lift

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,10 +1,5 @@
 jdkVersion = "17"
 
-# don't run eslint... it is for js and will detect false positives 
-# in javadoc directories.
-
-disableTools = ["eslint"]
-
 # Enable PMD, which is disabled by default.
 # Now I know why it is disabled by default.... It takes forever to run.
 # customTools = [ "https://help.sonatype.com/lift/files/78578763/78578764/1/1623180860953/pmd.sh rulesets/java/quickstart.xml" ]
@@ -18,11 +13,3 @@ disableTools = ["eslint"]
 # numbers of random numbers. So ignore predictable random warnings. 
 
 ignoreRules = ["PREDICTABLE_RANDOM"]
-
-# Ignore results from these directories
-
-ignoreFiles = """
-docs/api/jquery/
-src/test/
-*.js
-"""


### PR DESCRIPTION
## Summary
Updated configuration file for Sonatype Lift. Removed unnecessary list of excluded directories. The defaults are sufficient. Also removed obsolete rule related to excluding JS related tools. That is left over configuration from when we previously served the javadocs from the default branch's doc directory. For quite some time now, it has been served from the gh-pages branch. That rule was in place to prevent false positives associated with javadocs use of JS. This project is strictly a Java project. Since javadocs no longer served from default branch, there is no risk that Lift will attempt to scan them.

## Closing Issues
Closes #244 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
