### PR TITLE
Deprecated sampleReservoir, samplePool, and sampleInsertion methods of SequenceSampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-10-15
+## [Unreleased] - 2022-10-16
 
 ### Added
 * EditDistanceDouble: extracted from EditDistance (for sequences) all of the distancef methods for
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * EditDistance (for sequences)
 
 ### Deprecated
+* The SequenceSampler.sampleReservoir methods, which are now replaced by the SequenceReservoirSampler class.
+* The SequenceSampler.samplePool methods, which are now replaced by the SequencePoolSampler class.
+* The SequenceSampler.sampleInsertion methods, which are now replaced by the SequenceInsertionSampler class.
 
 ### Removed
 

--- a/src/main/java/org/cicirello/sequences/SequenceSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceSampler.java
@@ -470,6 +470,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -478,6 +480,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static int[] sampleReservoir(int[] source, int k, int[] target) {
 		return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -496,6 +499,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -504,6 +509,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static long[] sampleReservoir(long[] source, int k, long[] target) {
 		return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -522,6 +528,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -530,6 +538,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static short[] sampleReservoir(short[] source, int k, short[] target) {
 		return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -548,6 +557,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -556,6 +567,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static byte[] sampleReservoir(byte[] source, int k, byte[] target) {
 		return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -574,6 +586,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -582,6 +596,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static char[] sampleReservoir(char[] source, int k, char[] target) {
 		return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -600,6 +615,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length()).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -608,6 +625,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length()
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static char[] sampleReservoir(String source, int k, char[] target) {
 		return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -626,6 +644,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -634,6 +654,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static double[] sampleReservoir(double[] source, int k, double[] target) {
 		return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -652,6 +673,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -660,6 +683,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static float[] sampleReservoir(float[] source, int k, float[] target) {
 		return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -678,6 +702,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -687,6 +713,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static <T> T[] sampleReservoir(T[] source, int k, T[] target) {
 		return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -707,6 +734,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequencePoolSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -715,6 +744,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static int[] samplePool(int[] source, int k, int[] target) {
 		return SequencePoolSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -734,6 +764,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequencePoolSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -742,6 +774,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static long[] samplePool(long[] source, int k, long[] target) {
 		return SequencePoolSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -761,6 +794,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequencePoolSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -769,6 +804,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static short[] samplePool(short[] source, int k, short[] target) {
 		return SequencePoolSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -788,6 +824,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequencePoolSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -796,6 +834,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static byte[] samplePool(byte[] source, int k, byte[] target) {
 		return SequencePoolSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -815,6 +854,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequencePoolSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -823,6 +864,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static char[] samplePool(char[] source, int k, char[] target) {
 		return SequencePoolSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -842,6 +884,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequencePoolSampler} class.
+	 *
 	 * @param source The source to sample.
 	 * @param k The number of random samples (must be no greater than source.length()).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -850,6 +894,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length()
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static char[] samplePool(String source, int k, char[] target) {
 		return SequencePoolSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -869,6 +914,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequencePoolSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -877,6 +924,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static double[] samplePool(double[] source, int k, double[] target) {
 		return SequencePoolSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -896,6 +944,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequencePoolSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -904,6 +954,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static float[] samplePool(float[] source, int k, float[] target) {
 		return SequencePoolSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -923,6 +974,8 @@ public final class SequenceSampler {
 	 * <p>This method is safe to use with threads, as it uses ThreadLocalRandom
 	 * as the underlying source of randomness.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequencePoolSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -932,6 +985,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static <T> T[] samplePool(T[] source, int k, T[] target) {
 		return SequencePoolSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -956,6 +1010,8 @@ public final class SequenceSampler {
 	 * pseudorandom number generator, and is thus safe, and efficient (i.e., non-blocking), 
 	 * for use with threads.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceInsertionSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -964,6 +1020,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static int[] sampleInsertion(int[] source, int k, int[] target) {
 		return SequenceInsertionSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -987,6 +1044,8 @@ public final class SequenceSampler {
 	 * pseudorandom number generator, and is thus safe, and efficient (i.e., non-blocking), 
 	 * for use with threads.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceInsertionSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -995,6 +1054,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static long[] sampleInsertion(long[] source, int k, long[] target) {
 		return SequenceInsertionSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -1018,6 +1078,8 @@ public final class SequenceSampler {
 	 * pseudorandom number generator, and is thus safe, and efficient (i.e., non-blocking), 
 	 * for use with threads.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceInsertionSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -1026,6 +1088,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static short[] sampleInsertion(short[] source, int k, short[] target) {
 		return SequenceInsertionSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -1049,6 +1112,8 @@ public final class SequenceSampler {
 	 * pseudorandom number generator, and is thus safe, and efficient (i.e., non-blocking), 
 	 * for use with threads.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceInsertionSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -1057,6 +1122,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static byte[] sampleInsertion(byte[] source, int k, byte[] target) {
 		return SequenceInsertionSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -1080,6 +1146,8 @@ public final class SequenceSampler {
 	 * pseudorandom number generator, and is thus safe, and efficient (i.e., non-blocking), 
 	 * for use with threads.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceInsertionSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -1088,6 +1156,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static char[] sampleInsertion(char[] source, int k, char[] target) {
 		return SequenceInsertionSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -1111,6 +1180,8 @@ public final class SequenceSampler {
 	 * pseudorandom number generator, and is thus safe, and efficient (i.e., non-blocking), 
 	 * for use with threads.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceInsertionSampler} class.
+	 *
 	 * @param source The source to sample.
 	 * @param k The number of random samples (must be no greater than source.length()).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -1119,6 +1190,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length()
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static char[] sampleInsertion(String source, int k, char[] target) {
 		return SequenceInsertionSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -1142,6 +1214,8 @@ public final class SequenceSampler {
 	 * pseudorandom number generator, and is thus safe, and efficient (i.e., non-blocking), 
 	 * for use with threads.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceInsertionSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -1150,6 +1224,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static double[] sampleInsertion(double[] source, int k, double[] target) {
 		return SequenceInsertionSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -1173,6 +1248,8 @@ public final class SequenceSampler {
 	 * pseudorandom number generator, and is thus safe, and efficient (i.e., non-blocking), 
 	 * for use with threads.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceInsertionSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -1181,6 +1258,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static float[] sampleInsertion(float[] source, int k, float[] target) {
 		return SequenceInsertionSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}
@@ -1204,6 +1282,8 @@ public final class SequenceSampler {
 	 * pseudorandom number generator, and is thus safe, and efficient (i.e., non-blocking), 
 	 * for use with threads.</p>
 	 *
+	 * @deprecated This method is deprecated, and replaced by the {@link SequenceInsertionSampler} class.
+	 *
 	 * @param source The source array to sample.
 	 * @param k The number of random samples (must be no greater than source.length).
 	 * @param target An array to hold the result.  If target is null or target.length is less than k, 
@@ -1213,6 +1293,7 @@ public final class SequenceSampler {
 	 * @throws IllegalArgumentException if k &gt; source.length
 	 * @throws NegativeArraySizeException if k &lt; 0
 	 */
+	@Deprecated
 	public static <T> T[] sampleInsertion(T[] source, int k, T[] target) {
 		return SequenceInsertionSampler.sample(source, k, target, ThreadLocalRandom.current());
 	}

--- a/src/main/java/org/cicirello/sequences/SequenceSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceSampler.java
@@ -162,9 +162,8 @@ public final class SequenceSampler {
 	 * given source array.  All n choose k combinations are equally
 	 * likely, where n is the length of the source array.</p>
 	 *
-	 * <p>This method chooses among the samplePool, 
-	 * sampleReservoir, and sampleInsertion 
-	 * methods based on the values of n and k.</p>
+	 * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler}, 
+	 * and {@link SequenceInsertionSampler} classes based on the values of n and k.</p>
 	 *
 	 * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling
 	 * was described in: Vincent A. Cicirello. 2022. <a href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle 
@@ -195,9 +194,8 @@ public final class SequenceSampler {
 	 * given source array.  All n choose k combinations are equally
 	 * likely, where n is the length of the source array.</p>
 	 *
-	 * <p>This method chooses among the samplePool, 
-	 * sampleReservoir, and sampleInsertion 
-	 * methods based on the values of n and k.</p>
+	 * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler}, 
+	 * and {@link SequenceInsertionSampler} classes based on the values of n and k.</p>
 	 *
 	 * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling
 	 * was described in: Vincent A. Cicirello. 2022. <a href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle 
@@ -228,9 +226,8 @@ public final class SequenceSampler {
 	 * given source array.  All n choose k combinations are equally
 	 * likely, where n is the length of the source array.</p>
 	 *
-	 * <p>This method chooses among the samplePool, 
-	 * sampleReservoir, and sampleInsertion 
-	 * methods based on the values of n and k.</p>
+	 * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler}, 
+	 * and {@link SequenceInsertionSampler} classes based on the values of n and k.</p>
 	 *
 	 * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling
 	 * was described in: Vincent A. Cicirello. 2022. <a href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle 
@@ -261,9 +258,8 @@ public final class SequenceSampler {
 	 * given source array.  All n choose k combinations are equally
 	 * likely, where n is the length of the source array.</p>
 	 *
-	 * <p>This method chooses among the samplePool, 
-	 * sampleReservoir, and sampleInsertion 
-	 * methods based on the values of n and k.</p>
+	 * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler}, 
+	 * and {@link SequenceInsertionSampler} classes based on the values of n and k.</p>
 	 *
 	 * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling
 	 * was described in: Vincent A. Cicirello. 2022. <a href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle 
@@ -294,9 +290,8 @@ public final class SequenceSampler {
 	 * given source array.  All n choose k combinations are equally
 	 * likely, where n is the length of the source array.</p>
 	 *
-	 * <p>This method chooses among the samplePool, 
-	 * sampleReservoir, and sampleInsertion 
-	 * methods based on the values of n and k.</p>
+	 * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler}, 
+	 * and {@link SequenceInsertionSampler} classes based on the values of n and k.</p>
 	 *
 	 * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling
 	 * was described in: Vincent A. Cicirello. 2022. <a href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle 
@@ -327,9 +322,8 @@ public final class SequenceSampler {
 	 * given source String.  All n choose k combinations are equally
 	 * likely, where n is the length of the source String.</p>
 	 *
-	 * <p>This method chooses among the samplePool, 
-	 * sampleReservoir, and sampleInsertion 
-	 * methods based on the values of n and k.</p>
+	 * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler}, 
+	 * and {@link SequenceInsertionSampler} classes based on the values of n and k.</p>
 	 *
 	 * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling
 	 * was described in: Vincent A. Cicirello. 2022. <a href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle 
@@ -360,9 +354,8 @@ public final class SequenceSampler {
 	 * given source array.  All n choose k combinations are equally
 	 * likely, where n is the length of the source array.</p>
 	 *
-	 * <p>This method chooses among the samplePool, 
-	 * sampleReservoir, and sampleInsertion 
-	 * methods based on the values of n and k.</p>
+	 * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler}, 
+	 * and {@link SequenceInsertionSampler} classes based on the values of n and k.</p>
 	 *
 	 * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling
 	 * was described in: Vincent A. Cicirello. 2022. <a href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle 
@@ -393,9 +386,8 @@ public final class SequenceSampler {
 	 * given source array.  All n choose k combinations are equally
 	 * likely, where n is the length of the source array.</p>
 	 *
-	 * <p>This method chooses among the samplePool, 
-	 * sampleReservoir, and sampleInsertion 
-	 * methods based on the values of n and k.</p>
+	 * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler}, 
+	 * and {@link SequenceInsertionSampler} classes based on the values of n and k.</p>
 	 *
 	 * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling
 	 * was described in: Vincent A. Cicirello. 2022. <a href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle 
@@ -426,9 +418,8 @@ public final class SequenceSampler {
 	 * given source array.  All n choose k combinations are equally
 	 * likely, where n is the length of the source array.</p>
 	 *
-	 * <p>This method chooses among the samplePool, 
-	 * sampleReservoir, and sampleInsertion 
-	 * methods based on the values of n and k.</p>
+	 * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler}, 
+	 * and {@link SequenceInsertionSampler} classes based on the values of n and k.</p>
 	 *
 	 * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling
 	 * was described in: Vincent A. Cicirello. 2022. <a href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle 


### PR DESCRIPTION
## Summary
Deprecated the following:
* The SequenceSampler.sampleReservoir methods, which are now replaced by the SequenceReservoirSampler class.
* The SequenceSampler.samplePool methods, which are now replaced by the SequencePoolSampler class.
* The SequenceSampler.sampleInsertion methods, which are now replaced by the SequenceInsertionSampler class.

## Closing Issues
Closes #272 
Closes #273 
Closes #274 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
