### PR TITLE
Implemented SequenceSampler interface in SequenceReservoirSampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - 2022-11-18
 
 ### Added
+* Added the SequenceSampler interface's methods to SequenceReservoirSampler.
 
 ### Changed
 * SequenceSampler converted from a utility class of static methods to an interface, retaining the existing static
@@ -15,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 ### Removed
+* SequenceSampler.sampleReservoir methods, previously deprecated in 4.3.0, replaced by the SequenceReservoirSampler class.
 
 ### Fixed
 

--- a/src/main/java/org/cicirello/sequences/AbstractSequenceSampler.java
+++ b/src/main/java/org/cicirello/sequences/AbstractSequenceSampler.java
@@ -34,7 +34,6 @@ abstract class AbstractSequenceSampler {
 
   /** prevent instantiation with a private constructor. */
   AbstractSequenceSampler() {}
-  ;
 
   static void validateK(int k, int sourceLength) {
     if (k > sourceLength) {

--- a/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
@@ -26,8 +26,7 @@ import org.cicirello.math.rand.RandomIndexer;
 import org.cicirello.util.ArrayMinimumLengthEnforcer;
 
 /**
- * SequenceReservoirSampler is a class of utility methods for efficiently generating random samples
- * of array elements, without replacement.
+ * SequenceReservoirSampler generates random samples of array elements, without replacement.
  *
  * <p>The methods of this class use the reservoir sampling algorithm (Algorithm R) from J. Vitter's
  * 1985 article "Random Sampling with a Reservoir" from ACM Transactions on Mathematical Software.
@@ -38,10 +37,118 @@ import org.cicirello.util.ArrayMinimumLengthEnforcer;
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
-public final class SequenceReservoirSampler extends AbstractSequenceSampler {
+public final class SequenceReservoirSampler extends AbstractSequenceSampler
+    implements SequenceSampler {
 
-  /** Class of static utility methods so prevent instantiation with a private constructor. */
-  private SequenceReservoirSampler() {}
+  private final RandomGenerator r;
+
+  /**
+   * Constructs a sampler wrapping a RandomGenerator used as the source of randomness.
+   *
+   * @param r The source of randomness.
+   */
+  public SequenceReservoirSampler(RandomGenerator r) {
+    this.r = r;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws IllegalArgumentException if k &gt; source.length
+   * @throws NegativeArraySizeException if k &lt; 0
+   */
+  @Override
+  public int[] nextSample(int[] source, int k, int[] target) {
+    return sample(source, k, target, r);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws IllegalArgumentException if k &gt; source.length
+   * @throws NegativeArraySizeException if k &lt; 0
+   */
+  @Override
+  public long[] nextSample(long[] source, int k, long[] target) {
+    return sample(source, k, target, r);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws IllegalArgumentException if k &gt; source.length
+   * @throws NegativeArraySizeException if k &lt; 0
+   */
+  @Override
+  public short[] nextSample(short[] source, int k, short[] target) {
+    return sample(source, k, target, r);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws IllegalArgumentException if k &gt; source.length
+   * @throws NegativeArraySizeException if k &lt; 0
+   */
+  @Override
+  public byte[] nextSample(byte[] source, int k, byte[] target) {
+    return sample(source, k, target, r);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws IllegalArgumentException if k &gt; source.length
+   * @throws NegativeArraySizeException if k &lt; 0
+   */
+  @Override
+  public double[] nextSample(double[] source, int k, double[] target) {
+    return sample(source, k, target, r);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws IllegalArgumentException if k &gt; source.length
+   * @throws NegativeArraySizeException if k &lt; 0
+   */
+  @Override
+  public float[] nextSample(float[] source, int k, float[] target) {
+    return sample(source, k, target, r);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws IllegalArgumentException if k &gt; source.length
+   * @throws NegativeArraySizeException if k &lt; 0
+   */
+  @Override
+  public char[] nextSample(char[] source, int k, char[] target) {
+    return sample(source, k, target, r);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws IllegalArgumentException if k &gt; source.length()
+   * @throws NegativeArraySizeException if k &lt; 0
+   */
+  @Override
+  public char[] nextSample(String source, int k, char[] target) {
+    return sample(source, k, target, r);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @throws IllegalArgumentException if k &gt; source.length
+   * @throws NegativeArraySizeException if k &lt; 0
+   */
+  @Override
+  public <T> T[] nextSample(T[] source, int k, T[] target) {
+    return sample(source, k, target, r);
+  }
 
   /**
    * Generates a random sample of k elements, without replacement, from a given source array. All n

--- a/src/main/java/org/cicirello/sequences/SequenceSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceSampler.java
@@ -146,6 +146,18 @@ public interface SequenceSampler {
    * Generates a random sample, without replacement, from a given source array with a specified
    * probability of an element's inclusion in the sample.
    *
+   * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler},
+   * and {@link SequenceInsertionSampler} classes based on the values of n and p.
+   *
+   * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling was
+   * described in: Vincent A. Cicirello. 2022. <a
+   * href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle Mutation: Evolving
+   * Permutations via Cycle Induction</a>, <i>Applied Sciences</i>, 12(11), Article 5506 (June
+   * 2022). doi:<a href="https://doi.org/10.3390/app12115506">10.3390/app12115506</a>
+   *
+   * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
+   * and efficient (i.e., non-blocking), for use with threads.
+   *
    * @param source The array from which to sample.
    * @param p The probability that element is included in the sample. The expected sample size is
    *     source.length * p.
@@ -158,6 +170,18 @@ public interface SequenceSampler {
   /**
    * Generates a random sample, without replacement, from a given source array with a specified
    * probability of an element's inclusion in the sample.
+   *
+   * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler},
+   * and {@link SequenceInsertionSampler} classes based on the values of n and p.
+   *
+   * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling was
+   * described in: Vincent A. Cicirello. 2022. <a
+   * href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle Mutation: Evolving
+   * Permutations via Cycle Induction</a>, <i>Applied Sciences</i>, 12(11), Article 5506 (June
+   * 2022). doi:<a href="https://doi.org/10.3390/app12115506">10.3390/app12115506</a>
+   *
+   * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
+   * and efficient (i.e., non-blocking), for use with threads.
    *
    * @param source The array from which to sample.
    * @param p The probability that element is included in the sample. The expected sample size is
@@ -172,6 +196,18 @@ public interface SequenceSampler {
    * Generates a random sample, without replacement, from a given source array with a specified
    * probability of an element's inclusion in the sample.
    *
+   * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler},
+   * and {@link SequenceInsertionSampler} classes based on the values of n and p.
+   *
+   * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling was
+   * described in: Vincent A. Cicirello. 2022. <a
+   * href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle Mutation: Evolving
+   * Permutations via Cycle Induction</a>, <i>Applied Sciences</i>, 12(11), Article 5506 (June
+   * 2022). doi:<a href="https://doi.org/10.3390/app12115506">10.3390/app12115506</a>
+   *
+   * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
+   * and efficient (i.e., non-blocking), for use with threads.
+   *
    * @param source The array from which to sample.
    * @param p The probability that element is included in the sample. The expected sample size is
    *     source.length * p.
@@ -184,6 +220,18 @@ public interface SequenceSampler {
   /**
    * Generates a random sample, without replacement, from a given source array with a specified
    * probability of an element's inclusion in the sample.
+   *
+   * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler},
+   * and {@link SequenceInsertionSampler} classes based on the values of n and p.
+   *
+   * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling was
+   * described in: Vincent A. Cicirello. 2022. <a
+   * href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle Mutation: Evolving
+   * Permutations via Cycle Induction</a>, <i>Applied Sciences</i>, 12(11), Article 5506 (June
+   * 2022). doi:<a href="https://doi.org/10.3390/app12115506">10.3390/app12115506</a>
+   *
+   * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
+   * and efficient (i.e., non-blocking), for use with threads.
    *
    * @param source The array from which to sample.
    * @param p The probability that element is included in the sample. The expected sample size is
@@ -198,6 +246,18 @@ public interface SequenceSampler {
    * Generates a random sample, without replacement, from a given source array with a specified
    * probability of an element's inclusion in the sample.
    *
+   * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler},
+   * and {@link SequenceInsertionSampler} classes based on the values of n and p.
+   *
+   * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling was
+   * described in: Vincent A. Cicirello. 2022. <a
+   * href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle Mutation: Evolving
+   * Permutations via Cycle Induction</a>, <i>Applied Sciences</i>, 12(11), Article 5506 (June
+   * 2022). doi:<a href="https://doi.org/10.3390/app12115506">10.3390/app12115506</a>
+   *
+   * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
+   * and efficient (i.e., non-blocking), for use with threads.
+   *
    * @param source The array from which to sample.
    * @param p The probability that element is included in the sample. The expected sample size is
    *     source.length * p.
@@ -210,6 +270,18 @@ public interface SequenceSampler {
   /**
    * Generates a random sample, without replacement, from a given source array with a specified
    * probability of an element's inclusion in the sample.
+   *
+   * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler},
+   * and {@link SequenceInsertionSampler} classes based on the values of n and p.
+   *
+   * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling was
+   * described in: Vincent A. Cicirello. 2022. <a
+   * href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle Mutation: Evolving
+   * Permutations via Cycle Induction</a>, <i>Applied Sciences</i>, 12(11), Article 5506 (June
+   * 2022). doi:<a href="https://doi.org/10.3390/app12115506">10.3390/app12115506</a>
+   *
+   * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
+   * and efficient (i.e., non-blocking), for use with threads.
    *
    * @param source The array from which to sample.
    * @param p The probability that element is included in the sample. The expected sample size is
@@ -224,6 +296,18 @@ public interface SequenceSampler {
    * Generates a random sample, without replacement, from a given source array with a specified
    * probability of an element's inclusion in the sample.
    *
+   * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler},
+   * and {@link SequenceInsertionSampler} classes based on the values of n and p.
+   *
+   * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling was
+   * described in: Vincent A. Cicirello. 2022. <a
+   * href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle Mutation: Evolving
+   * Permutations via Cycle Induction</a>, <i>Applied Sciences</i>, 12(11), Article 5506 (June
+   * 2022). doi:<a href="https://doi.org/10.3390/app12115506">10.3390/app12115506</a>
+   *
+   * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
+   * and efficient (i.e., non-blocking), for use with threads.
+   *
    * @param source The array from which to sample.
    * @param p The probability that element is included in the sample. The expected sample size is
    *     source.length * p.
@@ -237,6 +321,18 @@ public interface SequenceSampler {
    * Generates a random sample, without replacement, from a given String with a specified
    * probability of a character's inclusion in the sample.
    *
+   * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler},
+   * and {@link SequenceInsertionSampler} classes based on the values of n and p.
+   *
+   * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling was
+   * described in: Vincent A. Cicirello. 2022. <a
+   * href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle Mutation: Evolving
+   * Permutations via Cycle Induction</a>, <i>Applied Sciences</i>, 12(11), Article 5506 (June
+   * 2022). doi:<a href="https://doi.org/10.3390/app12115506">10.3390/app12115506</a>
+   *
+   * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
+   * and efficient (i.e., non-blocking), for use with threads.
+   *
    * @param source The String from which to sample.
    * @param p The probability that a character is included in the sample. The expected sample size
    *     is source.length() * p.
@@ -249,6 +345,18 @@ public interface SequenceSampler {
   /**
    * Generates a random sample, without replacement, from a given source array with a specified
    * probability of an element's inclusion in the sample.
+   *
+   * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler},
+   * and {@link SequenceInsertionSampler} classes based on the values of n and p.
+   *
+   * <p>This approach combining reservoir sampling, pool sampling, and insertion sampling was
+   * described in: Vincent A. Cicirello. 2022. <a
+   * href="https://www.cicirello.org/publications/applsci-12-05506.pdf">Cycle Mutation: Evolving
+   * Permutations via Cycle Induction</a>, <i>Applied Sciences</i>, 12(11), Article 5506 (June
+   * 2022). doi:<a href="https://doi.org/10.3390/app12115506">10.3390/app12115506</a>
+   *
+   * <p>This method uses ThreadLocalRandom as the pseudorandom number generator, and is thus safe,
+   * and efficient (i.e., non-blocking), for use with threads.
    *
    * @param source The array from which to sample.
    * @param p The probability that element is included in the sample. The expected sample size is
@@ -529,250 +637,6 @@ public interface SequenceSampler {
    */
   public static <T> T[] sample(T[] source, int k, T[] target) {
     return SequenceCompositeSampler.sample(source, k, target, ThreadLocalRandom.current());
-  }
-
-  /**
-   * Generates a random sample of k elements, without replacement, from a given source array. All n
-   * choose k combinations are equally likely, where n is the length of the source array.
-   *
-   * <p>Uses the reservoir sampling algorithm (Algorithm R) from J. Vitter's 1985 article "Random
-   * Sampling with a Reservoir" from ACM Transactions on Mathematical Software. The runtime is O(n)
-   * and it generates O(n-k) random numbers. Thus, it is an especially good choice as k approaches
-   * n. Only constant extra space required.
-   *
-   * <p>This method is safe to use with threads, as it uses ThreadLocalRandom as the underlying
-   * source of randomness.
-   *
-   * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler}
-   *     class.
-   * @param source The source array to sample.
-   * @param k The number of random samples (must be no greater than source.length).
-   * @param target An array to hold the result. If target is null or target.length is less than k,
-   *     then this method will construct a new array for the result.
-   * @return An array containing the random sample.
-   * @throws IllegalArgumentException if k &gt; source.length
-   * @throws NegativeArraySizeException if k &lt; 0
-   */
-  @Deprecated
-  public static int[] sampleReservoir(int[] source, int k, int[] target) {
-    return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
-  }
-
-  /**
-   * Generates a random sample of k elements, without replacement, from a given source array. All n
-   * choose k combinations are equally likely, where n is the length of the source array.
-   *
-   * <p>Uses the reservoir sampling algorithm (Algorithm R) from J. Vitter's 1985 article "Random
-   * Sampling with a Reservoir" from ACM Transactions on Mathematical Software. The runtime is O(n)
-   * and it generates O(n-k) random numbers. Thus, it is an especially good choice as k approaches
-   * n. Only constant extra space required.
-   *
-   * <p>This method is safe to use with threads, as it uses ThreadLocalRandom as the underlying
-   * source of randomness.
-   *
-   * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler}
-   *     class.
-   * @param source The source array to sample.
-   * @param k The number of random samples (must be no greater than source.length).
-   * @param target An array to hold the result. If target is null or target.length is less than k,
-   *     then this method will construct a new array for the result.
-   * @return An array containing the random sample.
-   * @throws IllegalArgumentException if k &gt; source.length
-   * @throws NegativeArraySizeException if k &lt; 0
-   */
-  @Deprecated
-  public static long[] sampleReservoir(long[] source, int k, long[] target) {
-    return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
-  }
-
-  /**
-   * Generates a random sample of k elements, without replacement, from a given source array. All n
-   * choose k combinations are equally likely, where n is the length of the source array.
-   *
-   * <p>Uses the reservoir sampling algorithm (Algorithm R) from J. Vitter's 1985 article "Random
-   * Sampling with a Reservoir" from ACM Transactions on Mathematical Software. The runtime is O(n)
-   * and it generates O(n-k) random numbers. Thus, it is an especially good choice as k approaches
-   * n. Only constant extra space required.
-   *
-   * <p>This method is safe to use with threads, as it uses ThreadLocalRandom as the underlying
-   * source of randomness.
-   *
-   * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler}
-   *     class.
-   * @param source The source array to sample.
-   * @param k The number of random samples (must be no greater than source.length).
-   * @param target An array to hold the result. If target is null or target.length is less than k,
-   *     then this method will construct a new array for the result.
-   * @return An array containing the random sample.
-   * @throws IllegalArgumentException if k &gt; source.length
-   * @throws NegativeArraySizeException if k &lt; 0
-   */
-  @Deprecated
-  public static short[] sampleReservoir(short[] source, int k, short[] target) {
-    return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
-  }
-
-  /**
-   * Generates a random sample of k elements, without replacement, from a given source array. All n
-   * choose k combinations are equally likely, where n is the length of the source array.
-   *
-   * <p>Uses the reservoir sampling algorithm (Algorithm R) from J. Vitter's 1985 article "Random
-   * Sampling with a Reservoir" from ACM Transactions on Mathematical Software. The runtime is O(n)
-   * and it generates O(n-k) random numbers. Thus, it is an especially good choice as k approaches
-   * n. Only constant extra space required.
-   *
-   * <p>This method is safe to use with threads, as it uses ThreadLocalRandom as the underlying
-   * source of randomness.
-   *
-   * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler}
-   *     class.
-   * @param source The source array to sample.
-   * @param k The number of random samples (must be no greater than source.length).
-   * @param target An array to hold the result. If target is null or target.length is less than k,
-   *     then this method will construct a new array for the result.
-   * @return An array containing the random sample.
-   * @throws IllegalArgumentException if k &gt; source.length
-   * @throws NegativeArraySizeException if k &lt; 0
-   */
-  @Deprecated
-  public static byte[] sampleReservoir(byte[] source, int k, byte[] target) {
-    return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
-  }
-
-  /**
-   * Generates a random sample of k elements, without replacement, from a given source array. All n
-   * choose k combinations are equally likely, where n is the length of the source array.
-   *
-   * <p>Uses the reservoir sampling algorithm (Algorithm R) from J. Vitter's 1985 article "Random
-   * Sampling with a Reservoir" from ACM Transactions on Mathematical Software. The runtime is O(n)
-   * and it generates O(n-k) random numbers. Thus, it is an especially good choice as k approaches
-   * n. Only constant extra space required.
-   *
-   * <p>This method is safe to use with threads, as it uses ThreadLocalRandom as the underlying
-   * source of randomness.
-   *
-   * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler}
-   *     class.
-   * @param source The source array to sample.
-   * @param k The number of random samples (must be no greater than source.length).
-   * @param target An array to hold the result. If target is null or target.length is less than k,
-   *     then this method will construct a new array for the result.
-   * @return An array containing the random sample.
-   * @throws IllegalArgumentException if k &gt; source.length
-   * @throws NegativeArraySizeException if k &lt; 0
-   */
-  @Deprecated
-  public static char[] sampleReservoir(char[] source, int k, char[] target) {
-    return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
-  }
-
-  /**
-   * Generates a random sample of k chars, without replacement, from a given source String. All n
-   * choose k combinations are equally likely, where n is the length of the source String.
-   *
-   * <p>Uses the reservoir sampling algorithm (Algorithm R) from J. Vitter's 1985 article "Random
-   * Sampling with a Reservoir" from ACM Transactions on Mathematical Software. The runtime is O(n)
-   * and it generates O(n-k) random numbers. Thus, it is an especially good choice as k approaches
-   * n. Only constant extra space required.
-   *
-   * <p>This method is safe to use with threads, as it uses ThreadLocalRandom as the underlying
-   * source of randomness.
-   *
-   * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler}
-   *     class.
-   * @param source The source array to sample.
-   * @param k The number of random samples (must be no greater than source.length()).
-   * @param target An array to hold the result. If target is null or target.length is less than k,
-   *     then this method will construct a new array for the result.
-   * @return An array containing the random sample.
-   * @throws IllegalArgumentException if k &gt; source.length()
-   * @throws NegativeArraySizeException if k &lt; 0
-   */
-  @Deprecated
-  public static char[] sampleReservoir(String source, int k, char[] target) {
-    return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
-  }
-
-  /**
-   * Generates a random sample of k elements, without replacement, from a given source array. All n
-   * choose k combinations are equally likely, where n is the length of the source array.
-   *
-   * <p>Uses the reservoir sampling algorithm (Algorithm R) from J. Vitter's 1985 article "Random
-   * Sampling with a Reservoir" from ACM Transactions on Mathematical Software. The runtime is O(n)
-   * and it generates O(n-k) random numbers. Thus, it is an especially good choice as k approaches
-   * n. Only constant extra space required.
-   *
-   * <p>This method is safe to use with threads, as it uses ThreadLocalRandom as the underlying
-   * source of randomness.
-   *
-   * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler}
-   *     class.
-   * @param source The source array to sample.
-   * @param k The number of random samples (must be no greater than source.length).
-   * @param target An array to hold the result. If target is null or target.length is less than k,
-   *     then this method will construct a new array for the result.
-   * @return An array containing the random sample.
-   * @throws IllegalArgumentException if k &gt; source.length
-   * @throws NegativeArraySizeException if k &lt; 0
-   */
-  @Deprecated
-  public static double[] sampleReservoir(double[] source, int k, double[] target) {
-    return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
-  }
-
-  /**
-   * Generates a random sample of k elements, without replacement, from a given source array. All n
-   * choose k combinations are equally likely, where n is the length of the source array.
-   *
-   * <p>Uses the reservoir sampling algorithm (Algorithm R) from J. Vitter's 1985 article "Random
-   * Sampling with a Reservoir" from ACM Transactions on Mathematical Software. The runtime is O(n)
-   * and it generates O(n-k) random numbers. Thus, it is an especially good choice as k approaches
-   * n. Only constant extra space required.
-   *
-   * <p>This method is safe to use with threads, as it uses ThreadLocalRandom as the underlying
-   * source of randomness.
-   *
-   * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler}
-   *     class.
-   * @param source The source array to sample.
-   * @param k The number of random samples (must be no greater than source.length).
-   * @param target An array to hold the result. If target is null or target.length is less than k,
-   *     then this method will construct a new array for the result.
-   * @return An array containing the random sample.
-   * @throws IllegalArgumentException if k &gt; source.length
-   * @throws NegativeArraySizeException if k &lt; 0
-   */
-  @Deprecated
-  public static float[] sampleReservoir(float[] source, int k, float[] target) {
-    return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
-  }
-
-  /**
-   * Generates a random sample of k elements, without replacement, from a given source array. All n
-   * choose k combinations are equally likely, where n is the length of the source array.
-   *
-   * <p>Uses the reservoir sampling algorithm (Algorithm R) from J. Vitter's 1985 article "Random
-   * Sampling with a Reservoir" from ACM Transactions on Mathematical Software. The runtime is O(n)
-   * and it generates O(n-k) random numbers. Thus, it is an especially good choice as k approaches
-   * n. Only constant extra space required.
-   *
-   * <p>This method is safe to use with threads, as it uses ThreadLocalRandom as the underlying
-   * source of randomness.
-   *
-   * @deprecated This method is deprecated, and replaced by the {@link SequenceReservoirSampler}
-   *     class.
-   * @param source The source array to sample.
-   * @param k The number of random samples (must be no greater than source.length).
-   * @param target An array to hold the result. If target is null or target.length is less than k,
-   *     then this method will construct a new array for the result.
-   * @param <T> The type of array elements.
-   * @return An array containing the random sample.
-   * @throws IllegalArgumentException if k &gt; source.length
-   * @throws NegativeArraySizeException if k &lt; 0
-   */
-  @Deprecated
-  public static <T> T[] sampleReservoir(T[] source, int k, T[] target) {
-    return SequenceReservoirSampler.sample(source, k, target, ThreadLocalRandom.current());
   }
 
   /**

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerByteTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerByteTests.java
@@ -23,14 +23,16 @@ package org.cicirello.sequences;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
+import java.util.SplittableRandom;
 import org.junit.jupiter.api.*;
 
-/** Internal helpers for tests of sequence samplers. */
+/** JUnit tests for sequence samplers of bytes. */
 public class SequenceSamplerByteTests {
 
   @Test
   public void testSampleReservoir() {
-    validateSamples(SequenceSampler::sampleReservoir);
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
   }
 
   @Test

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerCharTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerCharTests.java
@@ -23,14 +23,16 @@ package org.cicirello.sequences;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
+import java.util.SplittableRandom;
 import org.junit.jupiter.api.*;
 
-/** Internal helpers for tests of sequence samplers. */
+/** JUnit tests for sequence samplers of chars. */
 public class SequenceSamplerCharTests {
 
   @Test
   public void testSampleReservoir() {
-    validateSamples(SequenceSampler::sampleReservoir);
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
   }
 
   @Test

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerDoubleTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerDoubleTests.java
@@ -23,14 +23,16 @@ package org.cicirello.sequences;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
+import java.util.SplittableRandom;
 import org.junit.jupiter.api.*;
 
-/** Internal helpers for tests of sequence samplers. */
+/** JUnit tests for sequence samplers of doubles. */
 public class SequenceSamplerDoubleTests {
 
   @Test
   public void testSampleReservoir() {
-    validateSamples(SequenceSampler::sampleReservoir);
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
   }
 
   @Test

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerFloatTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerFloatTests.java
@@ -23,14 +23,16 @@ package org.cicirello.sequences;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
+import java.util.SplittableRandom;
 import org.junit.jupiter.api.*;
 
-/** Internal helpers for tests of sequence samplers. */
+/** JUnit tests for sequence samplers of floats. */
 public class SequenceSamplerFloatTests {
 
   @Test
   public void testSampleReservoir() {
-    validateSamples(SequenceSampler::sampleReservoir);
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
   }
 
   @Test

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerIntTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerIntTests.java
@@ -23,14 +23,16 @@ package org.cicirello.sequences;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
+import java.util.SplittableRandom;
 import org.junit.jupiter.api.*;
 
-/** Internal helpers for tests of sequence samplers. */
+/** JUnit tests for sequence samplers of ints. */
 public class SequenceSamplerIntTests {
 
   @Test
   public void testSampleReservoir() {
-    validateSamples(SequenceSampler::sampleReservoir);
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
   }
 
   @Test

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerLongTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerLongTests.java
@@ -23,14 +23,16 @@ package org.cicirello.sequences;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
+import java.util.SplittableRandom;
 import org.junit.jupiter.api.*;
 
-/** Internal helpers for tests of sequence samplers. */
+/** JUnit tests for sequence samplers of longs. */
 public class SequenceSamplerLongTests {
 
   @Test
   public void testSampleReservoir() {
-    validateSamples(SequenceSampler::sampleReservoir);
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
   }
 
   @Test

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerObjectTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerObjectTests.java
@@ -23,14 +23,16 @@ package org.cicirello.sequences;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
+import java.util.SplittableRandom;
 import org.junit.jupiter.api.*;
 
-/** Internal helpers for tests of sequence samplers. */
+/** JUnit tests for sequence samplers of objects. */
 public class SequenceSamplerObjectTests {
 
   @Test
   public void testSampleReservoir() {
-    validateSamples(SequenceSampler::sampleReservoir);
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
   }
 
   @Test

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerShortTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerShortTests.java
@@ -23,14 +23,16 @@ package org.cicirello.sequences;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
+import java.util.SplittableRandom;
 import org.junit.jupiter.api.*;
 
-/** Internal helpers for tests of sequence samplers. */
+/** JUnit tests for sequence samplers of shorts. */
 public class SequenceSamplerShortTests {
 
   @Test
   public void testSampleReservoir() {
-    validateSamples(SequenceSampler::sampleReservoir);
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
   }
 
   @Test

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerStringTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerStringTests.java
@@ -23,14 +23,16 @@ package org.cicirello.sequences;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
+import java.util.SplittableRandom;
 import org.junit.jupiter.api.*;
 
-/** Internal helpers for tests of sequence samplers. */
+/** JUnit tests for sequence samplers of Strings. */
 public class SequenceSamplerStringTests {
 
   @Test
   public void testSampleReservoir() {
-    validateSamples(SequenceSampler::sampleReservoir);
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
   }
 
   @Test


### PR DESCRIPTION
## Summary
Added the SequenceSampler interface's methods to SequenceReservoirSampler. Also removed SequenceSampler.sampleReservoir methods, previously deprecated in 4.3.0, replaced by the SequenceReservoirSampler class.

## Closing Issues
Closes #278. 
This is also part of #276 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
