### PR TITLE
Add SequenceSampler.nextSample methods with probability of sampling element

### DIFF
--- a/src/main/java/org/cicirello/sequences/SequenceSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceSampler.java
@@ -146,6 +146,124 @@ public interface SequenceSampler {
    * Generates a random sample, without replacement, from a given source array with a specified
    * probability of an element's inclusion in the sample.
    *
+   * @param source The array from which to sample.
+   * @param p The probability that element is included in the sample. The expected sample size is
+   *     source.length * p.
+   * @return An array containing the sample, whose sample size is simply the length of the array.
+   */
+  default int[] nextSample(int[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
+  }
+
+  /**
+   * Generates a random sample, without replacement, from a given source array with a specified
+   * probability of an element's inclusion in the sample.
+   *
+   * @param source The array from which to sample.
+   * @param p The probability that element is included in the sample. The expected sample size is
+   *     source.length * p.
+   * @return An array containing the sample, whose sample size is simply the length of the array.
+   */
+  default long[] nextSample(long[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
+  }
+
+  /**
+   * Generates a random sample, without replacement, from a given source array with a specified
+   * probability of an element's inclusion in the sample.
+   *
+   * @param source The array from which to sample.
+   * @param p The probability that element is included in the sample. The expected sample size is
+   *     source.length * p.
+   * @return An array containing the sample, whose sample size is simply the length of the array.
+   */
+  default short[] nextSample(short[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
+  }
+
+  /**
+   * Generates a random sample, without replacement, from a given source array with a specified
+   * probability of an element's inclusion in the sample.
+   *
+   * @param source The array from which to sample.
+   * @param p The probability that element is included in the sample. The expected sample size is
+   *     source.length * p.
+   * @return An array containing the sample, whose sample size is simply the length of the array.
+   */
+  default byte[] nextSample(byte[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
+  }
+
+  /**
+   * Generates a random sample, without replacement, from a given source array with a specified
+   * probability of an element's inclusion in the sample.
+   *
+   * @param source The array from which to sample.
+   * @param p The probability that element is included in the sample. The expected sample size is
+   *     source.length * p.
+   * @return An array containing the sample, whose sample size is simply the length of the array.
+   */
+  default double[] nextSample(double[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
+  }
+
+  /**
+   * Generates a random sample, without replacement, from a given source array with a specified
+   * probability of an element's inclusion in the sample.
+   *
+   * @param source The array from which to sample.
+   * @param p The probability that element is included in the sample. The expected sample size is
+   *     source.length * p.
+   * @return An array containing the sample, whose sample size is simply the length of the array.
+   */
+  default float[] nextSample(float[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
+  }
+
+  /**
+   * Generates a random sample, without replacement, from a given source array with a specified
+   * probability of an element's inclusion in the sample.
+   *
+   * @param source The array from which to sample.
+   * @param p The probability that element is included in the sample. The expected sample size is
+   *     source.length * p.
+   * @return An array containing the sample, whose sample size is simply the length of the array.
+   */
+  default char[] nextSample(char[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
+  }
+
+  /**
+   * Generates a random sample, without replacement, from a given source String with a specified
+   * probability of an element's inclusion in the sample.
+   *
+   * @param source The String from which to sample.
+   * @param p The probability that element is included in the sample. The expected sample size is
+   *     source.length() * p.
+   * @return An array containing the sample, whose sample size is simply the length of the array.
+   */
+  default char[] nextSample(String source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length(), p), null);
+  }
+
+  /**
+   * Generates a random sample, without replacement, from a given source array with a specified
+   * probability of an element's inclusion in the sample.
+   *
+   * @param <T> The type of array elements.
+   * @param source The array from which to sample.
+   * @param p The probability that element is included in the sample. The expected sample size is
+   *     source.length * p.
+   * @return An array containing the sample, whose sample size is simply the length of the array.
+   */
+  default <T> T[] nextSample(T[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
+  }
+
+  /**
+   * Generates a random sample, without replacement, from a given source array with a specified
+   * probability of an element's inclusion in the sample.
+   *
    * <p>This method chooses among the {@link SequencePoolSampler}, {@link SequenceReservoirSampler},
    * and {@link SequenceInsertionSampler} classes based on the values of n and p.
    *

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerByteTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerByteTests.java
@@ -54,12 +54,40 @@ public class SequenceSamplerByteTests {
   }
 
   @Test
+  public void testSampleCompositeP() {
+    SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleReservoirP() {
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSamplePoolP() {
+    SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleInsertionP() {
+    SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
   public void testSample() {
     validateSamples(SequenceSampler::sample);
   }
 
   @Test
   public void testSampleByteP() {
+    validateWithP(SequenceSampler::sample);
+  }
+
+  private void validateWithP(PSampler sampler) {
     for (int n = 1; n <= 10; n++) {
       byte[] allDiff = new byte[n];
       byte[] mixedQuantities = new byte[n];
@@ -78,11 +106,16 @@ public class SequenceSamplerByteTests {
         allSame[i] = 100;
       }
       for (double p = 0.25; p <= 0.8; p += 0.25) {
-        validateSample(allDiff, SequenceSampler.sample(allDiff, p));
-        validateSample(mixedQuantities, SequenceSampler.sample(mixedQuantities, p));
-        validateSample(allSame, SequenceSampler.sample(allSame, p));
+        validateSample(allDiff, sampler.sample(allDiff, p));
+        validateSample(mixedQuantities, sampler.sample(mixedQuantities, p));
+        validateSample(allSame, sampler.sample(allSame, p));
       }
     }
+  }
+
+  @FunctionalInterface
+  interface PSampler {
+    byte[] sample(byte[] source, double p);
   }
 
   @FunctionalInterface

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerCharTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerCharTests.java
@@ -54,12 +54,40 @@ public class SequenceSamplerCharTests {
   }
 
   @Test
+  public void testSampleCompositeP() {
+    SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleReservoirP() {
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSamplePoolP() {
+    SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleInsertionP() {
+    SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
   public void testSample() {
     validateSamples(SequenceSampler::sample);
   }
 
   @Test
   public void testSampleCharP() {
+    validateWithP(SequenceSampler::sample);
+  }
+
+  private void validateWithP(PSampler sampler) {
     for (int n = 1; n <= 10; n++) {
       char[] allDiff = new char[n];
       char[] mixedQuantities = new char[n];
@@ -78,11 +106,16 @@ public class SequenceSamplerCharTests {
         allSame[i] = 100;
       }
       for (double p = 0.25; p <= 0.8; p += 0.25) {
-        validateSample(allDiff, SequenceSampler.sample(allDiff, p));
-        validateSample(mixedQuantities, SequenceSampler.sample(mixedQuantities, p));
-        validateSample(allSame, SequenceSampler.sample(allSame, p));
+        validateSample(allDiff, sampler.sample(allDiff, p));
+        validateSample(mixedQuantities, sampler.sample(mixedQuantities, p));
+        validateSample(allSame, sampler.sample(allSame, p));
       }
     }
+  }
+
+  @FunctionalInterface
+  interface PSampler {
+    char[] sample(char[] source, double p);
   }
 
   @FunctionalInterface

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerDoubleTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerDoubleTests.java
@@ -54,12 +54,40 @@ public class SequenceSamplerDoubleTests {
   }
 
   @Test
+  public void testSampleCompositeP() {
+    SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleReservoirP() {
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSamplePoolP() {
+    SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleInsertionP() {
+    SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
   public void testSample() {
     validateSamples(SequenceSampler::sample);
   }
 
   @Test
   public void testSampleDoubleP() {
+    validateWithP(SequenceSampler::sample);
+  }
+
+  private void validateWithP(PSampler sampler) {
     for (int n = 1; n <= 10; n++) {
       double[] allDiff = new double[n];
       double[] mixedQuantities = new double[n];
@@ -78,11 +106,16 @@ public class SequenceSamplerDoubleTests {
         allSame[i] = 100;
       }
       for (double p = 0.25; p <= 0.8; p += 0.25) {
-        validateSample(allDiff, SequenceSampler.sample(allDiff, p));
-        validateSample(mixedQuantities, SequenceSampler.sample(mixedQuantities, p));
-        validateSample(allSame, SequenceSampler.sample(allSame, p));
+        validateSample(allDiff, sampler.sample(allDiff, p));
+        validateSample(mixedQuantities, sampler.sample(mixedQuantities, p));
+        validateSample(allSame, sampler.sample(allSame, p));
       }
     }
+  }
+
+  @FunctionalInterface
+  interface PSampler {
+    double[] sample(double[] source, double p);
   }
 
   @FunctionalInterface

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerFloatTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerFloatTests.java
@@ -54,12 +54,40 @@ public class SequenceSamplerFloatTests {
   }
 
   @Test
+  public void testSampleCompositeP() {
+    SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleReservoirP() {
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSamplePoolP() {
+    SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleInsertionP() {
+    SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
   public void testSample() {
     validateSamples(SequenceSampler::sample);
   }
 
   @Test
   public void testSampleFloatP() {
+    validateWithP(SequenceSampler::sample);
+  }
+
+  private void validateWithP(PSampler sampler) {
     for (int n = 1; n <= 10; n++) {
       float[] allDiff = new float[n];
       float[] mixedQuantities = new float[n];
@@ -78,11 +106,16 @@ public class SequenceSamplerFloatTests {
         allSame[i] = 100;
       }
       for (double p = 0.25; p <= 0.8; p += 0.25) {
-        validateSample(allDiff, SequenceSampler.sample(allDiff, p));
-        validateSample(mixedQuantities, SequenceSampler.sample(mixedQuantities, p));
-        validateSample(allSame, SequenceSampler.sample(allSame, p));
+        validateSample(allDiff, sampler.sample(allDiff, p));
+        validateSample(mixedQuantities, sampler.sample(mixedQuantities, p));
+        validateSample(allSame, sampler.sample(allSame, p));
       }
     }
+  }
+
+  @FunctionalInterface
+  interface PSampler {
+    float[] sample(float[] source, double p);
   }
 
   @FunctionalInterface

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerIntTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerIntTests.java
@@ -54,12 +54,40 @@ public class SequenceSamplerIntTests {
   }
 
   @Test
+  public void testSampleCompositeP() {
+    SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleReservoirP() {
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSamplePoolP() {
+    SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleInsertionP() {
+    SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
   public void testSample() {
     validateSamples(SequenceSampler::sample);
   }
 
   @Test
   public void testSampleIntP() {
+    validateWithP(SequenceSampler::sample);
+  }
+
+  private void validateWithP(PSampler sampler) {
     for (int n = 1; n <= 10; n++) {
       int[] allDiff = new int[n];
       int[] mixedQuantities = new int[n];
@@ -78,11 +106,16 @@ public class SequenceSamplerIntTests {
         allSame[i] = 100;
       }
       for (double p = 0.25; p <= 0.8; p += 0.25) {
-        validateSample(allDiff, SequenceSampler.sample(allDiff, p));
-        validateSample(mixedQuantities, SequenceSampler.sample(mixedQuantities, p));
-        validateSample(allSame, SequenceSampler.sample(allSame, p));
+        validateSample(allDiff, sampler.sample(allDiff, p));
+        validateSample(mixedQuantities, sampler.sample(mixedQuantities, p));
+        validateSample(allSame, sampler.sample(allSame, p));
       }
     }
+  }
+
+  @FunctionalInterface
+  interface PSampler {
+    int[] sample(int[] source, double p);
   }
 
   @FunctionalInterface

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerLongTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerLongTests.java
@@ -54,12 +54,40 @@ public class SequenceSamplerLongTests {
   }
 
   @Test
+  public void testSampleCompositeP() {
+    SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleReservoirP() {
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSamplePoolP() {
+    SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleInsertionP() {
+    SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
   public void testSample() {
     validateSamples(SequenceSampler::sample);
   }
 
   @Test
   public void testSampleLongP() {
+    validateWithP(SequenceSampler::sample);
+  }
+
+  private void validateWithP(PSampler sampler) {
     for (int n = 1; n <= 10; n++) {
       long[] allDiff = new long[n];
       long[] mixedQuantities = new long[n];
@@ -78,11 +106,16 @@ public class SequenceSamplerLongTests {
         allSame[i] = 100;
       }
       for (double p = 0.25; p <= 0.8; p += 0.25) {
-        validateSample(allDiff, SequenceSampler.sample(allDiff, p));
-        validateSample(mixedQuantities, SequenceSampler.sample(mixedQuantities, p));
-        validateSample(allSame, SequenceSampler.sample(allSame, p));
+        validateSample(allDiff, sampler.sample(allDiff, p));
+        validateSample(mixedQuantities, sampler.sample(mixedQuantities, p));
+        validateSample(allSame, sampler.sample(allSame, p));
       }
     }
+  }
+
+  @FunctionalInterface
+  interface PSampler {
+    long[] sample(long[] source, double p);
   }
 
   @FunctionalInterface

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerObjectTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerObjectTests.java
@@ -54,12 +54,40 @@ public class SequenceSamplerObjectTests {
   }
 
   @Test
+  public void testSampleCompositeP() {
+    SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleReservoirP() {
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSamplePoolP() {
+    SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleInsertionP() {
+    SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
   public void testSample() {
     validateSamples(SequenceSampler::sample);
   }
 
   @Test
   public void testSampleObjectsP() {
+    validateWithP(SequenceSampler::sample);
+  }
+
+  private void validateWithP(PSampler sampler) {
     for (int n = 1; n <= 10; n++) {
       Integer[] allDiff = new Integer[n];
       Integer[] mixedQuantities = new Integer[n];
@@ -78,11 +106,16 @@ public class SequenceSamplerObjectTests {
         allSame[i] = 100;
       }
       for (double p = 0.25; p <= 0.8; p += 0.25) {
-        validateSample(allDiff, SequenceSampler.sample(allDiff, p));
-        validateSample(mixedQuantities, SequenceSampler.sample(mixedQuantities, p));
-        validateSample(allSame, SequenceSampler.sample(allSame, p));
+        validateSample(allDiff, sampler.sample(allDiff, p));
+        validateSample(mixedQuantities, sampler.sample(mixedQuantities, p));
+        validateSample(allSame, sampler.sample(allSame, p));
       }
     }
+  }
+
+  @FunctionalInterface
+  interface PSampler {
+    <T> T[] sample(T[] source, double p);
   }
 
   @FunctionalInterface

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerShortTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerShortTests.java
@@ -54,12 +54,40 @@ public class SequenceSamplerShortTests {
   }
 
   @Test
+  public void testSampleCompositeP() {
+    SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleReservoirP() {
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSamplePoolP() {
+    SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleInsertionP() {
+    SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
   public void testSample() {
     validateSamples(SequenceSampler::sample);
   }
 
   @Test
   public void testSampleShortP() {
+    validateWithP(SequenceSampler::sample);
+  }
+
+  private void validateWithP(PSampler sampler) {
     for (int n = 1; n <= 10; n++) {
       short[] allDiff = new short[n];
       short[] mixedQuantities = new short[n];
@@ -78,11 +106,16 @@ public class SequenceSamplerShortTests {
         allSame[i] = 100;
       }
       for (double p = 0.25; p <= 0.8; p += 0.25) {
-        validateSample(allDiff, SequenceSampler.sample(allDiff, p));
-        validateSample(mixedQuantities, SequenceSampler.sample(mixedQuantities, p));
-        validateSample(allSame, SequenceSampler.sample(allSame, p));
+        validateSample(allDiff, sampler.sample(allDiff, p));
+        validateSample(mixedQuantities, sampler.sample(mixedQuantities, p));
+        validateSample(allSame, sampler.sample(allSame, p));
       }
     }
+  }
+
+  @FunctionalInterface
+  interface PSampler {
+    short[] sample(short[] source, double p);
   }
 
   @FunctionalInterface

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerStringTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerStringTests.java
@@ -54,12 +54,40 @@ public class SequenceSamplerStringTests {
   }
 
   @Test
+  public void testSampleCompositeP() {
+    SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleReservoirP() {
+    SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSamplePoolP() {
+    SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
+  public void testSampleInsertionP() {
+    SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+  }
+
+  @Test
   public void testSample() {
     validateSamples(SequenceSampler::sample);
   }
 
   @Test
   public void testSampleStringP() {
+    validateWithP(SequenceSampler::sample);
+  }
+
+  private void validateWithP(PSampler sampler) {
     for (int n = 1; n <= 10; n++) {
       char[] allDiff = new char[n];
       char[] mixedQuantities = new char[n];
@@ -81,11 +109,16 @@ public class SequenceSamplerStringTests {
       String mixedQuantitiesS = new String(mixedQuantities);
       String allSameS = new String(allSame);
       for (double p = 0.25; p <= 0.8; p += 0.25) {
-        validateSample(allDiff, SequenceSampler.sample(allDiffS, p));
-        validateSample(mixedQuantities, SequenceSampler.sample(mixedQuantitiesS, p));
-        validateSample(allSame, SequenceSampler.sample(allSameS, p));
+        validateSample(allDiff, sampler.sample(allDiffS, p));
+        validateSample(mixedQuantities, sampler.sample(mixedQuantitiesS, p));
+        validateSample(allSame, sampler.sample(allSameS, p));
       }
     }
+  }
+
+  @FunctionalInterface
+  interface PSampler {
+    char[] sample(String source, double p);
   }
 
   @FunctionalInterface


### PR DESCRIPTION
## Summary
Add SequenceSampler.nextSample methods with probability of sampling element. Provided default implementations that delegate to the existing nextSample methods that have k as a parameter (default implementation chooses k with a random binomial).

## Closing Issues
Closes #303 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
