### PR TITLE
Cache hash on first call to Permutation.hashCode()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2023-04-07
+## [Unreleased] - 2023-04-13
 
 ### Added
 
 ### Changed
+* Permutation now caches hash on first call to hashCode() to optimize applications that rely heavily on hashing.
 
 ### Deprecated
 

--- a/src/main/java/org/cicirello/permutations/PermutationIterator.java
+++ b/src/main/java/org/cicirello/permutations/PermutationIterator.java
@@ -39,8 +39,8 @@ import org.cicirello.util.ArrayFiller;
  */
 public class PermutationIterator implements Iterator<Permutation> {
 
-  private Permutation p;
-  private int[] lastSwap;
+  private final Permutation p;
+  private final int[] lastSwap;
   private boolean done;
 
   /**
@@ -92,14 +92,14 @@ public class PermutationIterator implements Iterator<Permutation> {
       done = true;
     } else {
       for (int i = lastSwap.length - 2; i >= 0; i--) {
-        if (lastSwap[i] != i) p.swap(i, lastSwap[i]);
+        if (lastSwap[i] != i) p.internalSwap(i, lastSwap[i]);
         if (lastSwap[i] == lastSwap.length - 1) {
           lastSwap[i] = i;
           if (i == 0) done = true;
           continue;
         }
         lastSwap[i]++;
-        p.swap(i, lastSwap[i]);
+        p.internalSwap(i, lastSwap[i]);
         break;
       }
     }

--- a/src/test/java/org/cicirello/permutations/PermutationConstructorRelatedTests.java
+++ b/src/test/java/org/cicirello/permutations/PermutationConstructorRelatedTests.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -155,6 +155,7 @@ public class PermutationConstructorRelatedTests extends SharedTestHelpersPermuta
         Permutation copy = new Permutation(p);
         assertEquals(p, copy);
         assertEquals(p.hashCode(), copy.hashCode());
+        assertEquals(p.hashCode(), copy.hashCode());
       }
     }
   }
@@ -167,6 +168,7 @@ public class PermutationConstructorRelatedTests extends SharedTestHelpersPermuta
         Permutation copy = p.copy();
         assertEquals(p, copy);
         assertTrue(p != copy);
+        assertEquals(p.hashCode(), copy.hashCode());
         assertEquals(p.hashCode(), copy.hashCode());
       }
     }

--- a/src/test/java/org/cicirello/permutations/PermutationCycleTests.java
+++ b/src/test/java/org/cicirello/permutations/PermutationCycleTests.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -38,8 +38,10 @@ public class PermutationCycleTests {
       Permutation p2 = new Permutation(p);
       p2.cycle(indexes1);
       assertEquals(p, p2);
+      assertEquals(p.hashCode(), p2.hashCode());
       p2.cycle(indexes0);
       assertEquals(p, p2);
+      assertEquals(p.hashCode(), p2.hashCode());
     }
   }
 
@@ -52,7 +54,9 @@ public class PermutationCycleTests {
       Permutation p2 = new Permutation(p);
       indexes[0] = 0;
       indexes[1] = i - 1;
+      assertEquals(p.hashCode(), p2.hashCode());
       p2.cycle(indexes);
+      if (i > 1) assertNotEquals(p.hashCode(), p2.hashCode());
       assertEquals(p.get(0), p2.get(i - 1));
       assertEquals(p.get(i - 1), p2.get(0));
       for (int j = 1; j < i - 1; j++) {
@@ -64,7 +68,9 @@ public class PermutationCycleTests {
       Permutation p2 = new Permutation(p);
       indexes[1] = 0;
       indexes[0] = i - 1;
+      assertEquals(p.hashCode(), p2.hashCode());
       p2.cycle(indexes);
+      if (i > 1) assertNotEquals(p.hashCode(), p2.hashCode());
       assertEquals(p.get(0), p2.get(i - 1));
       assertEquals(p.get(i - 1), p2.get(0));
       for (int j = 1; j < i - 1; j++) {
@@ -76,7 +82,9 @@ public class PermutationCycleTests {
       Permutation p2 = new Permutation(p);
       indexes[0] = (i - 1) / 2;
       indexes[1] = indexes[0] + 1;
+      assertEquals(p.hashCode(), p2.hashCode());
       p2.cycle(indexes);
+      assertNotEquals(p.hashCode(), p2.hashCode());
       assertEquals(p.get(indexes[0]), p2.get(indexes[1]));
       assertEquals(p.get(indexes[1]), p2.get(indexes[0]));
       for (int j = 0; j < indexes[0]; j++) {

--- a/src/test/java/org/cicirello/permutations/PermutationInverseTests.java
+++ b/src/test/java/org/cicirello/permutations/PermutationInverseTests.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -68,14 +68,19 @@ public class PermutationInverseTests {
   public void testInvert() {
     int[] before = {4, 2, 5, 0, 3, 1};
     Permutation p = new Permutation(before);
+    int oldHash = p.hashCode();
     int[] expected = {3, 5, 1, 4, 0, 2};
     Permutation pExpected = new Permutation(expected);
     p.invert();
     assertEquals(pExpected, p);
+    assertEquals(pExpected.hashCode(), p.hashCode());
+    assertNotEquals(oldHash, p.hashCode());
     int[] array = {0, 1, 2, 3, 4, 5};
     p = new Permutation(array);
     pExpected = new Permutation(array);
+    assertEquals(pExpected.hashCode(), p.hashCode());
     p.invert();
     assertEquals(pExpected, p);
+    assertEquals(pExpected.hashCode(), p.hashCode());
   }
 }

--- a/src/test/java/org/cicirello/permutations/PermutationIteratorTests.java
+++ b/src/test/java/org/cicirello/permutations/PermutationIteratorTests.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *

--- a/src/test/java/org/cicirello/permutations/PermutationNoncontiguousScrambleTests.java
+++ b/src/test/java/org/cicirello/permutations/PermutationNoncontiguousScrambleTests.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -34,10 +34,12 @@ public class PermutationNoncontiguousScrambleTests {
     SplittableRandom r2 = new SplittableRandom(42);
     // Verify does nothing if permutation length < 2.
     Permutation p = new Permutation(1);
+    int oldHash = p.hashCode();
     int[] indexes = {0};
     for (int i = 0; i < 5; i++) {
       p.scramble(indexes, r2);
       assertEquals(0, p.get(0));
+      assertEquals(oldHash, p.hashCode());
       p.scramble(indexes);
       assertEquals(0, p.get(0));
     }
@@ -55,9 +57,11 @@ public class PermutationNoncontiguousScrambleTests {
       shouldChange[indexes[0]] = shouldChange[indexes[1]] = true;
       Permutation p = new Permutation(n, 0);
       Permutation p0 = new Permutation(p);
+      assertEquals(p0.hashCode(), p.hashCode());
       p.scramble(indexes, r2);
       assertEquals(0, p.get(n - 1));
       assertEquals(n - 1, p.get(0));
+      assertNotEquals(p0.hashCode(), p.hashCode());
       for (int i = 0; i < n; i++) {
         if (!shouldChange[i]) {
           assertEquals(p0.get(i), p.get(i));

--- a/src/test/java/org/cicirello/permutations/PermutationOperatorsTests.java
+++ b/src/test/java/org/cicirello/permutations/PermutationOperatorsTests.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -23,6 +23,7 @@ package org.cicirello.permutations;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.SplittableRandom;
 import org.junit.jupiter.api.*;
 
 /** JUnit tests for the applyThenValidate and apply methods of the Permutation class. */
@@ -45,7 +46,8 @@ public class PermutationOperatorsTests {
 
   @Test
   public void testUnaryOperator() {
-    Permutation p = new Permutation(10);
+    Permutation p = new Permutation(10, new SplittableRandom(42));
+    int oldHash = p.hashCode();
     p.apply(
         perm -> {
           for (int i = 0; i < perm.length; i++) {
@@ -55,6 +57,7 @@ public class PermutationOperatorsTests {
     for (int i = 0; i < 10; i++) {
       assertEquals(i, p.get(i));
     }
+    assertNotEquals(oldHash, p.hashCode());
     p.apply(
         perm -> {
           for (int i = 0; i < perm.length; i++) {
@@ -64,11 +67,13 @@ public class PermutationOperatorsTests {
     for (int i = 0; i < 10; i++) {
       assertEquals(9 - i, p.get(i));
     }
+    assertNotEquals(oldHash, p.hashCode());
   }
 
   @Test
   public void testValidatedUnaryOperator() {
-    final Permutation p = new Permutation(10);
+    final Permutation p = new Permutation(10, new SplittableRandom(42));
+    int oldHash = p.hashCode();
     p.applyThenValidate(
         perm -> {
           for (int i = 0; i < perm.length; i++) {
@@ -78,6 +83,7 @@ public class PermutationOperatorsTests {
     for (int i = 0; i < 10; i++) {
       assertEquals(i, p.get(i));
     }
+    assertNotEquals(oldHash, p.hashCode());
     p.applyThenValidate(
         perm -> {
           for (int i = 0; i < perm.length; i++) {
@@ -87,6 +93,7 @@ public class PermutationOperatorsTests {
     for (int i = 0; i < 10; i++) {
       assertEquals(9 - i, p.get(i));
     }
+    assertNotEquals(oldHash, p.hashCode());
     IllegalPermutationStateException thrown =
         assertThrows(
             IllegalPermutationStateException.class,
@@ -102,8 +109,10 @@ public class PermutationOperatorsTests {
 
   @Test
   public void testBinaryOperator() {
-    Permutation p1 = new Permutation(10);
-    Permutation p2 = new Permutation(10);
+    Permutation p1 = new Permutation(10, new SplittableRandom(42));
+    int oldHash1 = p1.hashCode();
+    Permutation p2 = new Permutation(10, new SplittableRandom(73));
+    int oldHash2 = p2.hashCode();
     p1.apply(
         (perm1, perm2) -> {
           for (int i = 0; i < perm1.length; i++) {
@@ -116,6 +125,8 @@ public class PermutationOperatorsTests {
       assertEquals(i, p1.get(i));
       assertEquals(9 - i, p2.get(i));
     }
+    assertNotEquals(oldHash1, p1.hashCode());
+    assertNotEquals(oldHash2, p2.hashCode());
     p1.apply(
         (perm1, perm2) -> {
           for (int i = 0; i < perm1.length; i++) {
@@ -128,12 +139,16 @@ public class PermutationOperatorsTests {
       assertEquals(i, p2.get(i));
       assertEquals(9 - i, p1.get(i));
     }
+    assertNotEquals(oldHash1, p1.hashCode());
+    assertNotEquals(oldHash2, p2.hashCode());
   }
 
   @Test
   public void testValidatedBinaryOperator() {
-    final Permutation p1 = new Permutation(10);
-    final Permutation p2 = new Permutation(10);
+    final Permutation p1 = new Permutation(10, new SplittableRandom(42));
+    int oldHash1 = p1.hashCode();
+    final Permutation p2 = new Permutation(10, new SplittableRandom(73));
+    int oldHash2 = p2.hashCode();
     p1.applyThenValidate(
         (perm1, perm2) -> {
           for (int i = 0; i < perm1.length; i++) {
@@ -146,6 +161,8 @@ public class PermutationOperatorsTests {
       assertEquals(i, p1.get(i));
       assertEquals(9 - i, p2.get(i));
     }
+    assertNotEquals(oldHash1, p1.hashCode());
+    assertNotEquals(oldHash2, p2.hashCode());
     p1.applyThenValidate(
         (perm1, perm2) -> {
           for (int i = 0; i < perm1.length; i++) {
@@ -158,6 +175,8 @@ public class PermutationOperatorsTests {
       assertEquals(i, p2.get(i));
       assertEquals(9 - i, p1.get(i));
     }
+    assertNotEquals(oldHash1, p1.hashCode());
+    assertNotEquals(oldHash2, p2.hashCode());
     IllegalPermutationStateException thrown =
         assertThrows(
             IllegalPermutationStateException.class,
@@ -175,7 +194,8 @@ public class PermutationOperatorsTests {
 
   @Test
   public void testFullUnaryOperator() {
-    Permutation p = new Permutation(10);
+    Permutation p = new Permutation(10, new SplittableRandom(42));
+    int oldHash = p.hashCode();
     p.apply(
         (perm, original) -> {
           for (int i = 0; i < perm.length; i++) {
@@ -186,6 +206,7 @@ public class PermutationOperatorsTests {
     for (int i = 0; i < 10; i++) {
       assertEquals(i, p.get(i));
     }
+    assertNotEquals(oldHash, p.hashCode());
     p.apply(
         (perm, original) -> {
           for (int i = 0; i < perm.length; i++) {
@@ -196,11 +217,13 @@ public class PermutationOperatorsTests {
     for (int i = 0; i < 10; i++) {
       assertEquals(9 - i, p.get(i));
     }
+    assertNotEquals(oldHash, p.hashCode());
   }
 
   @Test
   public void testValidatedFullUnaryOperator() {
-    final Permutation p = new Permutation(10);
+    final Permutation p = new Permutation(10, new SplittableRandom(42));
+    int oldHash = p.hashCode();
     p.applyThenValidate(
         (perm, original) -> {
           for (int i = 0; i < perm.length; i++) {
@@ -211,6 +234,7 @@ public class PermutationOperatorsTests {
     for (int i = 0; i < 10; i++) {
       assertEquals(i, p.get(i));
     }
+    assertNotEquals(oldHash, p.hashCode());
     p.applyThenValidate(
         (perm, original) -> {
           for (int i = 0; i < perm.length; i++) {
@@ -221,6 +245,7 @@ public class PermutationOperatorsTests {
     for (int i = 0; i < 10; i++) {
       assertEquals(9 - i, p.get(i));
     }
+    assertNotEquals(oldHash, p.hashCode());
     IllegalPermutationStateException thrown =
         assertThrows(
             IllegalPermutationStateException.class,
@@ -236,8 +261,10 @@ public class PermutationOperatorsTests {
 
   @Test
   public void testFullBinaryOperator() {
-    Permutation p1 = new Permutation(10);
-    Permutation p2 = new Permutation(10);
+    Permutation p1 = new Permutation(10, new SplittableRandom(42));
+    int oldHash1 = p1.hashCode();
+    Permutation p2 = new Permutation(10, new SplittableRandom(73));
+    int oldHash2 = p2.hashCode();
     p1.apply(
         (perm1, perm2, o1, o2) -> {
           for (int i = 0; i < perm1.length; i++) {
@@ -252,6 +279,8 @@ public class PermutationOperatorsTests {
       assertEquals(i, p1.get(i));
       assertEquals(9 - i, p2.get(i));
     }
+    assertNotEquals(oldHash1, p1.hashCode());
+    assertNotEquals(oldHash2, p2.hashCode());
     p1.apply(
         (perm1, perm2, o1, o2) -> {
           for (int i = 0; i < perm1.length; i++) {
@@ -266,12 +295,16 @@ public class PermutationOperatorsTests {
       assertEquals(i, p2.get(i));
       assertEquals(9 - i, p1.get(i));
     }
+    assertNotEquals(oldHash1, p1.hashCode());
+    assertNotEquals(oldHash2, p2.hashCode());
   }
 
   @Test
   public void testValidatedFullBinaryOperator() {
-    final Permutation p1 = new Permutation(10);
-    final Permutation p2 = new Permutation(10);
+    final Permutation p1 = new Permutation(10, new SplittableRandom(42));
+    int oldHash1 = p1.hashCode();
+    final Permutation p2 = new Permutation(10, new SplittableRandom(73));
+    int oldHash2 = p2.hashCode();
     p1.applyThenValidate(
         (perm1, perm2, o1, o2) -> {
           for (int i = 0; i < perm1.length; i++) {
@@ -286,6 +319,8 @@ public class PermutationOperatorsTests {
       assertEquals(i, p1.get(i));
       assertEquals(9 - i, p2.get(i));
     }
+    assertNotEquals(oldHash1, p1.hashCode());
+    assertNotEquals(oldHash2, p2.hashCode());
     p1.applyThenValidate(
         (perm1, perm2, o1, o2) -> {
           for (int i = 0; i < perm1.length; i++) {
@@ -300,6 +335,8 @@ public class PermutationOperatorsTests {
       assertEquals(i, p2.get(i));
       assertEquals(9 - i, p1.get(i));
     }
+    assertNotEquals(oldHash1, p1.hashCode());
+    assertNotEquals(oldHash2, p2.hashCode());
     IllegalPermutationStateException thrown =
         assertThrows(
             IllegalPermutationStateException.class,

--- a/src/test/java/org/cicirello/permutations/PermutationRemoveInsertTests.java
+++ b/src/test/java/org/cicirello/permutations/PermutationRemoveInsertTests.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -23,6 +23,7 @@ package org.cicirello.permutations;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.SplittableRandom;
 import org.junit.jupiter.api.*;
 
 /** JUnit tests for removing and reinserting. */
@@ -30,10 +31,11 @@ public class PermutationRemoveInsertTests {
 
   @Test
   public void testPermutationRemoveInsert() {
-    Permutation p = new Permutation(5);
+    Permutation p = new Permutation(5, new SplittableRandom(42));
     for (int i = 0; i < p.length(); i++) {
       for (int j = 0; j < p.length(); j++) {
         Permutation copy = new Permutation(p);
+        assertEquals(p.hashCode(), copy.hashCode());
         copy.removeAndInsert(i, j);
         if (i < j) {
           for (int k = 0; k < i; k++) {
@@ -46,6 +48,7 @@ public class PermutationRemoveInsertTests {
           for (int k = j + 1; k < p.length(); k++) {
             assertEquals(p.get(k), copy.get(k));
           }
+          assertNotEquals(p.hashCode(), copy.hashCode());
         } else if (i > j) {
           for (int k = 0; k < j; k++) {
             assertEquals(p.get(k), copy.get(k));
@@ -57,6 +60,7 @@ public class PermutationRemoveInsertTests {
           for (int k = i + 1; k < p.length(); k++) {
             assertEquals(p.get(k), copy.get(k));
           }
+          assertNotEquals(p.hashCode(), copy.hashCode());
         } else {
           assertEquals(p, copy);
         }
@@ -76,16 +80,20 @@ public class PermutationRemoveInsertTests {
     Permutation p = new Permutation(a);
     Permutation p1 = new Permutation(a1);
     Permutation mutant = new Permutation(p);
+    assertEquals(p.hashCode(), mutant.hashCode());
     mutant.removeAndInsert(7, 1, 0);
     assertEquals(p1, mutant);
+    assertNotEquals(p.hashCode(), mutant.hashCode());
     Permutation p2 = new Permutation(a2);
     mutant = new Permutation(p);
     mutant.removeAndInsert(2, 1, 10);
     assertEquals(p2, mutant);
     Permutation p3 = new Permutation(a3);
     mutant = new Permutation(p);
+    assertEquals(p.hashCode(), mutant.hashCode());
     mutant.removeAndInsert(7, 2, 0);
     assertEquals(p3, mutant);
+    assertNotEquals(p.hashCode(), mutant.hashCode());
     Permutation p4 = new Permutation(a4);
     mutant = new Permutation(p);
     mutant.removeAndInsert(1, 2, 9);

--- a/src/test/java/org/cicirello/permutations/PermutationReverseTests.java
+++ b/src/test/java/org/cicirello/permutations/PermutationReverseTests.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -23,6 +23,7 @@ package org.cicirello.permutations;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.SplittableRandom;
 import org.junit.jupiter.api.*;
 
 /** JUnit tests for reversing a Permutation. */
@@ -38,26 +39,35 @@ public class PermutationReverseTests {
   @Test
   public void testReverseComplete() {
     for (int n = 1; n <= 8; n *= 2) {
-      Permutation p = new Permutation(n);
+      Permutation p = new Permutation(n, new SplittableRandom(42));
       Permutation copy = new Permutation(p);
+      assertEquals(p.hashCode(), copy.hashCode());
       copy.reverse();
       for (int i = 0; i < n; i++) {
         assertEquals(p.get(i), copy.get(n - 1 - i));
+      }
+      if (n >= 2) {
+        assertNotEquals(p.hashCode(), copy.hashCode());
       }
     }
   }
 
   @Test
   public void testReverseSub() {
-    Permutation p = new Permutation(8);
+    Permutation p = new Permutation(8, new SplittableRandom(42));
     for (int j = 0; j < p.length(); j++) {
       for (int k = j + 1; k < p.length(); k++) {
         Permutation copy = new Permutation(p);
+        assertEquals(p.hashCode(), copy.hashCode());
         copy.reverse(j, k);
         validateReversal(p, copy, j, k);
+        assertNotEquals(p.hashCode(), copy.hashCode());
+
         copy = new Permutation(p);
+        assertEquals(p.hashCode(), copy.hashCode());
         copy.reverse(k, j);
         validateReversal(p, copy, j, k);
+        assertNotEquals(p.hashCode(), copy.hashCode());
       }
     }
   }

--- a/src/test/java/org/cicirello/permutations/PermutationRotateTests.java
+++ b/src/test/java/org/cicirello/permutations/PermutationRotateTests.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -23,6 +23,7 @@ package org.cicirello.permutations;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.SplittableRandom;
 import org.junit.jupiter.api.*;
 
 /** JUnit tests for rotating a Permutation. */
@@ -30,20 +31,28 @@ public class PermutationRotateTests {
 
   @Test
   public void testPermutationRotate() {
-    Permutation p = new Permutation(10);
+    Permutation p = new Permutation(10, new SplittableRandom(42));
     for (int r = 0; r < p.length(); r++) {
       Permutation copy = new Permutation(p);
+      assertEquals(p.hashCode(), copy.hashCode());
       copy.rotate(r);
       for (int i = 0; i < p.length(); i++) {
         int j = (i + r) % p.length();
         assertEquals(p.get(j), copy.get(i), "elements should be left rotated " + r + " places");
       }
+      if (r > 0) {
+        assertNotEquals(p.hashCode(), copy.hashCode());
+      }
     }
     Permutation copy = new Permutation(p);
+    assertEquals(p.hashCode(), copy.hashCode());
     copy.rotate(p.length());
     assertEquals(p, copy);
+    assertEquals(p.hashCode(), copy.hashCode());
     copy = new Permutation(p);
+    assertEquals(p.hashCode(), copy.hashCode());
     copy.rotate(-1);
+    assertNotEquals(p.hashCode(), copy.hashCode());
     for (int i = 1; i < p.length(); i++) {
       assertEquals(p.get(i - 1), copy.get(i), "elements should be RIGHT rotated 1 place");
     }

--- a/src/test/java/org/cicirello/permutations/PermutationScrambleTests.java
+++ b/src/test/java/org/cicirello/permutations/PermutationScrambleTests.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -50,7 +50,7 @@ public class PermutationScrambleTests extends SharedTestHelpersPermutation {
 
   @Test
   public void testScramble() {
-    SplittableRandom r2 = new SplittableRandom();
+    SplittableRandom r2 = new SplittableRandom(42);
     for (int i = 0; i < 8; i++) {
       Permutation p = new Permutation(i);
       for (int j = 0; j < 10; j++) {
@@ -58,20 +58,34 @@ public class PermutationScrambleTests extends SharedTestHelpersPermutation {
         p.scramble();
         validatePermutation(p, i);
         original = new Permutation(p);
+        assertEquals(original.hashCode(), p.hashCode());
         p.scramble(r2);
+        if (i >= 7) assertNotEquals(original.hashCode(), p.hashCode());
         validatePermutation(p, i);
+
         p.scramble(false);
         validatePermutation(p, i);
+
         p.scramble(r2, false);
         validatePermutation(p, i);
+
         original = new Permutation(p);
+        assertEquals(original.hashCode(), p.hashCode());
         p.scramble(true);
         validatePermutation(p, i);
-        if (i > 1) assertNotEquals(original, p);
+        if (i > 1) {
+          assertNotEquals(original, p);
+          assertNotEquals(original.hashCode(), p.hashCode());
+        }
+
         original = new Permutation(p);
+        assertEquals(original.hashCode(), p.hashCode());
         p.scramble(r2, true);
         validatePermutation(p, i);
-        if (i > 1) assertNotEquals(original, p);
+        if (i > 1) {
+          assertNotEquals(original, p);
+          assertNotEquals(original.hashCode(), p.hashCode());
+        }
       }
     }
   }
@@ -80,30 +94,39 @@ public class PermutationScrambleTests extends SharedTestHelpersPermutation {
   public void testScrambleFromItoJ() {
     SplittableRandom r2 = new SplittableRandom();
     for (int n = 4; n < 8; n++) {
-      Permutation p = new Permutation(n);
+      Permutation p = new Permutation(n, r2);
       Permutation original = new Permutation(p);
+      assertEquals(original.hashCode(), p.hashCode());
       p.scramble(1, n - 2);
       validatePermutation(p, n);
-      if (n > 1) assertNotEquals(original, p);
+      assertNotEquals(original, p);
+      assertNotEquals(original.hashCode(), p.hashCode());
       assertEquals(original.get(0), p.get(0));
       assertEquals(original.get(n - 1), p.get(n - 1));
+
       original = new Permutation(p);
+      assertEquals(original.hashCode(), p.hashCode());
       p.scramble(1, n - 2, r2);
       validatePermutation(p, n);
-      if (n > 1) assertNotEquals(original, p);
+      assertNotEquals(original, p);
+      assertNotEquals(original.hashCode(), p.hashCode());
       assertEquals(original.get(0), p.get(0));
       assertEquals(original.get(n - 1), p.get(n - 1));
+
       original = new Permutation(p);
       p.scramble(0, n - 1);
       validatePermutation(p, n);
-      if (n > 1) assertNotEquals(original, p);
+      assertNotEquals(original, p);
+
       original = new Permutation(p);
       p.scramble(0, n - 1, r2);
       validatePermutation(p, n);
-      if (n > 1) assertNotEquals(original, p);
+      assertNotEquals(original, p);
+
       original = new Permutation(p);
       p.scramble(1, 1, r2);
       assertEquals(original, p);
+
       original = new Permutation(p);
       p.scramble(1, 1);
       assertEquals(original, p);
@@ -111,13 +134,14 @@ public class PermutationScrambleTests extends SharedTestHelpersPermutation {
       original = new Permutation(p);
       p.scramble(n - 2, 1);
       validatePermutation(p, n);
-      if (n > 1) assertNotEquals(original, p);
+      assertNotEquals(original, p);
       assertEquals(original.get(0), p.get(0));
       assertEquals(original.get(n - 1), p.get(n - 1));
+
       original = new Permutation(p);
       p.scramble(n - 2, 1, r2);
       validatePermutation(p, n);
-      if (n > 1) assertNotEquals(original, p);
+      assertNotEquals(original, p);
       assertEquals(original.get(0), p.get(0));
       assertEquals(original.get(n - 1), p.get(n - 1));
     }

--- a/src/test/java/org/cicirello/permutations/PermutationSwapTests.java
+++ b/src/test/java/org/cicirello/permutations/PermutationSwapTests.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -27,6 +27,15 @@ import org.junit.jupiter.api.*;
 
 /** JUnit tests for swap and swapBlocks methods. */
 public class PermutationSwapTests {
+
+  @Test
+  public void testHashCodeInvalidation() {
+    Permutation p1 = new Permutation(4, 0);
+    Permutation p2 = new Permutation(4, 0);
+    assertEquals(p1.hashCode(), p2.hashCode());
+    p2.swap(1, 2);
+    assertNotEquals(p1.hashCode(), p2.hashCode());
+  }
 
   @Test
   public void testSwap() {

--- a/src/test/java/org/cicirello/permutations/PermutationToFromArraysTests.java
+++ b/src/test/java/org/cicirello/permutations/PermutationToFromArraysTests.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *

--- a/src/test/java/org/cicirello/permutations/SharedTestHelpersPermutation.java
+++ b/src/test/java/org/cicirello/permutations/SharedTestHelpersPermutation.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *


### PR DESCRIPTION
## Summary
Permutation now caches hash on first call to hashCode() to optimize applications that rely heavily on hashing.

## Closing Issues
Closes #329 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
