### PR TITLE
Refactor edit distance and related distance measures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - 2023-05-30
 
+**Breaking Changes**: Due to breaking changes, the next release will be a major release (see the Removed section below for details). Timing of that major release will likely be in the Fall of 2023 to coincide with the planned transition to Java 21 upon its release.
+
 ### Added
 
 ### Changed
+* Refactored to improve code quality and to perform minor optimizations of the following classes:
+  * org.cicirello.permutations.distance.EditDistance
+  * org.cicirello.sequences.distance.EditDistance
+  * org.cicirello.sequences.distance.EditDistanceDouble
 
 ### Deprecated
 
 ### Removed
+* Removed the previously deprecated (in v5.1.0) constructor `org.cicirello.sequences.distance.EditDistance(double, double, double)`. To compute edit distance with double-valued costs for arrays and other sequences, use the existing `EditDistanceDouble` class instead. This does not impact the class with the same name that computes edit distance for permutations (i.e., the `org.cicirello.permutations.distance.EditDistance` class still accepts doubles for the costs).
 
 ### Fixed
 

--- a/src/main/java/org/cicirello/permutations/distance/EditDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/EditDistance.java
@@ -39,7 +39,9 @@ import org.cicirello.permutations.Permutation;
  * edit operation. We chose this as the default as it is equivalent to counting the number of
  * reinsertion operations necessary to transform one permutation into the other, known as
  * Reinsertion Distance. A reinsertion operation removes an element and reinserts it in a different
- * position, and is treated as a single composite operation.
+ * position, and is treated as a single composite operation. However, the {@link
+ * ReinsertionDistance} class provides an implementation of a specialized algorithm that is more
+ * efficient for this special case.
  *
  * <p>Runtime: O(n<sup>2</sup>), where n is the permutation length.
  *
@@ -57,9 +59,10 @@ import org.cicirello.permutations.Permutation;
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
 public final class EditDistance implements PermutationDistanceMeasurerDouble {
-  private double insertCost;
-  private double deleteCost;
-  private double changeCost;
+
+  private final double insertCost;
+  private final double deleteCost;
+  private final double changeCost;
 
   /**
    * Constructs an EditDistance function.
@@ -67,8 +70,12 @@ public final class EditDistance implements PermutationDistanceMeasurerDouble {
    * @param insertCost Cost of an insertion operation.
    * @param deleteCost Cost of a deletion operation.
    * @param changeCost Cost of a change operation.
+   * @throws IllegalArgumentException if any of the costs are negative.
    */
   public EditDistance(double insertCost, double deleteCost, double changeCost) {
+    if (insertCost < 0.0 || deleteCost < 0.0 || changeCost < 0.0) {
+      throw new IllegalArgumentException("Costs must be non-negative.");
+    }
     this.insertCost = insertCost;
     this.deleteCost = deleteCost;
     this.changeCost = changeCost;
@@ -92,61 +99,29 @@ public final class EditDistance implements PermutationDistanceMeasurerDouble {
    */
   @Override
   public double distancef(Permutation p1, Permutation p2) {
-    int L1 = p1.length();
-    int L2 = p2.length();
-    if (L1 == L2 && L1 <= 1) return 0;
-    double[][] D = new double[L1 + 1][L2 + 1];
-    for (int i = 1; i <= L1; i++) {
+    int n = p1.length();
+    int m = p2.length();
+    if (n == m && n <= 1) return 0;
+    double[][] D = new double[n + 1][m + 1];
+    for (int i = 1; i <= n; i++) {
       D[i][0] = D[i - 1][0] + deleteCost;
     }
-    for (int j = 1; j <= L2; j++) {
+    for (int j = 1; j <= m; j++) {
       D[0][j] = D[0][j - 1] + insertCost;
     }
-    for (int i = 1; i <= L1; i++) {
-      for (int j = 1; j <= L2; j++) {
-        double m1 = D[i - 1][j - 1] + ((p1.get(i - 1) != p2.get(j - 1)) ? changeCost : 0);
-        double m2 = D[i - 1][j] + deleteCost;
-        double m3 = D[i][j - 1] + insertCost;
-        double min = m1;
-        if (m2 < min) min = m2;
-        if (m3 < min) min = m3;
-        D[i][j] = min;
+    for (int i = 1; i <= n; i++) {
+      for (int j = 1; j <= m; j++) {
+        D[i][j] =
+            min(
+                p1.get(i - 1) == p2.get(j - 1) ? D[i - 1][j - 1] : D[i - 1][j - 1] + changeCost,
+                D[i - 1][j] + deleteCost,
+                D[i][j - 1] + insertCost);
       }
     }
-    return D[L1][L2];
+    return D[n][m];
   }
 
-  /* // REMOVED FOR NOW
-   * The maxf method is not currently unsupported when computing
-   * edit distance.
-   *
-   * @throws UnsupportedOperationException If this method is invoked.
-   */
-  // @Override
-  // public double maxf(int length) {
-  // throw new UnsupportedOperationException("Unimplemented.");
-  /* // This is close but doesn't work.  Might be too complex to be worth computing here.
-  if (length <= 1) return 0;
-  double combined = insertCost + deleteCost;
-  if (combined <= changeCost) {
-  	return (length-1)*combined;
+  private double min(double m1, double m2, double m3) {
+    return Math.min(m1 < m2 ? m1 : m2, m3);
   }
-  if ((length & 1) == 0) {
-  	double m1 = (length-1)*combined;
-  	double m2 = length*changeCost;
-  	double m3 = combined + (length-2)*changeCost;
-  	double max = m1 < m2 ? m1 : m2;
-  	if (m3 < max) max = m3;
-  	return max;
-  } else {
-  	double m = (length-1)*changeCost;
-  	double m1 = (length-2)*combined;
-  	double m2 = length*changeCost;
-  	double m3 = combined + (length-2)*changeCost;
-  	double max = m1 < m2 ? m1 : m2;
-  	if (m3 < max) max = m3;
-  	return m > max ? m : max;
-  } */
-  // }
-
 }

--- a/src/main/java/org/cicirello/sequences/distance/EditDistance.java
+++ b/src/main/java/org/cicirello/sequences/distance/EditDistance.java
@@ -56,41 +56,11 @@ import java.util.List;
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
-public class EditDistance extends EditDistanceDouble implements SequenceDistanceMeasurer {
+public class EditDistance implements SequenceDistanceMeasurer {
 
-  private final int insert_i;
-  private final int delete_i;
-  private final int change_i;
-
-  /**
-   * Constructs an edit distance measure with the specified edit operation costs. With costs as
-   * doubles, all of the distancef methods that compute distance as double values are available. The
-   * distance methods that compute integer-valued distances may or may not be available if this
-   * constructor is used with double valued costs. If the costs are equal to integer values if cast
-   * to type double, then the distance methods will also function. Otherwise, they will throw an
-   * exception. For safety, it is recommended to only use the distancef methods if you use this
-   * constructor to pass costs as type double. If you desire integer valued distances, then use the
-   * other constructor to pass costs as ints.
-   *
-   * @param insertCost Cost of an insertion operation. Must be non-negative.
-   * @param deleteCost Cost of an deletion operation. Must be non-negative.
-   * @param changeCost Cost of an change operation. Must be non-negative.
-   * @throws IllegalArgumentException if any of the costs are negative.
-   * @deprecated For double-valued costs, use the {@link EditDistanceDouble} class instead.
-   */
-  @Deprecated
-  public EditDistance(double insertCost, double deleteCost, double changeCost) {
-    super(insertCost, deleteCost, changeCost);
-    if (isIntAsDouble(insertCost) && isIntAsDouble(deleteCost) && isIntAsDouble(changeCost)) {
-      insert_i = (int) insertCost;
-      delete_i = (int) deleteCost;
-      change_i = (int) changeCost;
-    } else {
-      // Use -1 on these to disallow use of distance (the one that returns an int)... make sure to
-      // throw an exception there
-      insert_i = delete_i = change_i = -1;
-    }
-  }
+  private final int insertCost;
+  private final int deleteCost;
+  private final int changeCost;
 
   /**
    * Constructs an edit distance measure with the specified edit operation costs.
@@ -101,199 +71,107 @@ public class EditDistance extends EditDistanceDouble implements SequenceDistance
    * @throws IllegalArgumentException if any of the costs are negative.
    */
   public EditDistance(int insertCost, int deleteCost, int changeCost) {
-    super(insertCost, deleteCost, changeCost);
-    insert_i = insertCost;
-    delete_i = deleteCost;
-    change_i = changeCost;
+    if (insertCost < 0 || deleteCost < 0 || changeCost < 0) {
+      throw new IllegalArgumentException("Costs must be non-negative.");
+    }
+    this.insertCost = insertCost;
+    this.deleteCost = deleteCost;
+    this.changeCost = changeCost;
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * @throws UnsupportedOperationException if costs were initialized with double values.
-   */
   @Override
   public final int distance(int[] s1, int[] s2) {
-    return distance(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_i);
+    return distance(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * @throws UnsupportedOperationException if costs were initialized with double values.
-   */
   @Override
   public final int distance(long[] s1, long[] s2) {
-    return distance(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_i);
+    return distance(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * @throws UnsupportedOperationException if costs were initialized with double values.
-   */
   @Override
   public final int distance(short[] s1, short[] s2) {
-    return distance(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_i);
+    return distance(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * @throws UnsupportedOperationException if costs were initialized with double values.
-   */
   @Override
   public final int distance(byte[] s1, byte[] s2) {
-    return distance(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_i);
+    return distance(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * @throws UnsupportedOperationException if costs were initialized with double values.
-   */
   @Override
   public final int distance(char[] s1, char[] s2) {
-    return distance(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_i);
+    return distance(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * @throws UnsupportedOperationException if costs were initialized with double values.
-   */
   @Override
   public final int distance(boolean[] s1, boolean[] s2) {
-    return distance(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_i);
+    return distance(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * @throws UnsupportedOperationException if costs were initialized with double values.
-   */
   @Override
   public final int distance(double[] s1, double[] s2) {
-    return distance(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_i);
+    return distance(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * @throws UnsupportedOperationException if costs were initialized with double values.
-   */
   @Override
   public final int distance(float[] s1, float[] s2) {
-    return distance(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_i);
+    return distance(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * @throws UnsupportedOperationException if costs were initialized with double values.
-   */
   @Override
   public final int distance(String s1, String s2) {
-    return distance(
-        s1.length(),
-        s2.length(),
-        (i, j, costIfSame) -> s1.charAt(i) == s2.charAt(j) ? costIfSame : costIfSame + change_i);
+    return distance(s1.length(), s2.length(), (i, j) -> s1.charAt(i) == s2.charAt(j));
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * @throws UnsupportedOperationException if costs were initialized with double values.
-   */
   @Override
   public final int distance(Object[] s1, Object[] s2) {
-    return distance(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i].equals(s2[j]) ? costIfSame : costIfSame + change_i);
+    return distance(s1.length, s2.length, (i, j) -> s1[i].equals(s2[j]));
   }
 
-  /**
-   * {@inheritDoc}
-   *
-   * @throws UnsupportedOperationException if costs were initialized with double values.
-   */
   @Override
   public final <T> int distance(List<T> s1, List<T> s2) {
-    return distance(s1.toArray(), s2.toArray());
+    return distance(s1.size(), s2.size(), (i, j) -> s1.get(i).equals(s2.get(j)));
   }
 
   @FunctionalInterface
-  private interface ChangeCost {
+  private interface Equals {
     /**
-     * Computes cost of change.
+     * Checks if elements are the same.
      *
      * @param i Index into first sequence.
      * @param j Index into second sequence.
-     * @param costIfSame The cost if the elements are the same.
-     * @return Cost for a change.
+     * @return true if and only if the corresponding elements are equal.
      */
-    int apply(int i, int j, int valueIfSame);
+    boolean same(int i, int j);
   }
 
-  private boolean isIntAsDouble(double d) {
-    return ((double) ((int) d)) == d;
-  }
-
-  private int distance(int n, int m, ChangeCost coster) {
+  private int distance(int n, int m, Equals compare) {
     int[][] D = initD(n, m);
     for (int i = 1; i <= n; i++) {
       for (int j = 1; j <= m; j++) {
         D[i][j] =
             min(
-                coster.apply(i - 1, j - 1, D[i - 1][j - 1]),
-                D[i - 1][j] + delete_i,
-                D[i][j - 1] + insert_i);
+                compare.same(i - 1, j - 1) ? D[i - 1][j - 1] : D[i - 1][j - 1] + changeCost,
+                D[i - 1][j] + deleteCost,
+                D[i][j - 1] + insertCost);
       }
     }
     return D[n][m];
   }
 
   private int[][] initD(int n, int m) {
-    if (insert_i < 0)
-      throw new UnsupportedOperationException(
-          "EditDistance.distance not supported for floating-point costs.");
     int[][] D = new int[n + 1][m + 1];
     for (int i = 1; i <= n; i++) {
-      D[i][0] = D[i - 1][0] + delete_i;
+      D[i][0] = D[i - 1][0] + deleteCost;
     }
     for (int j = 1; j <= m; j++) {
-      D[0][j] = D[0][j - 1] + insert_i;
+      D[0][j] = D[0][j - 1] + insertCost;
     }
     return D;
   }
 
   private int min(int m1, int m2, int m3) {
-    if (m2 < m1) m1 = m2;
-    return m3 < m1 ? m3 : m1;
+    return Math.min(m1 < m2 ? m1 : m2, m3);
   }
 }

--- a/src/main/java/org/cicirello/sequences/distance/EditDistanceDouble.java
+++ b/src/main/java/org/cicirello/sequences/distance/EditDistanceDouble.java
@@ -55,11 +55,11 @@ import java.util.List;
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>
  */
-public class EditDistanceDouble implements SequenceDistanceMeasurerDouble {
+public final class EditDistanceDouble implements SequenceDistanceMeasurerDouble {
 
-  private final double insert_d;
-  private final double delete_d;
-  private final double change_d;
+  private final double insertCost;
+  private final double deleteCost;
+  private final double changeCost;
 
   /**
    * Constructs an edit distance measure with the specified edit operation costs.
@@ -73,9 +73,9 @@ public class EditDistanceDouble implements SequenceDistanceMeasurerDouble {
     if (insertCost < 0.0 || deleteCost < 0.0 || changeCost < 0.0) {
       throw new IllegalArgumentException("Costs must be non-negative.");
     }
-    insert_d = insertCost;
-    delete_d = deleteCost;
-    change_d = changeCost;
+    this.insertCost = insertCost;
+    this.deleteCost = deleteCost;
+    this.changeCost = changeCost;
   }
 
   @Override
@@ -151,9 +151,9 @@ public class EditDistanceDouble implements SequenceDistanceMeasurerDouble {
       for (int j = 1; j <= m; j++) {
         D[i][j] =
             min(
-                compare.same(i - 1, j - 1) ? D[i - 1][j - 1] : D[i - 1][j - 1] + change_d,
-                D[i - 1][j] + delete_d,
-                D[i][j - 1] + insert_d);
+                compare.same(i - 1, j - 1) ? D[i - 1][j - 1] : D[i - 1][j - 1] + changeCost,
+                D[i - 1][j] + deleteCost,
+                D[i][j - 1] + insertCost);
       }
     }
     return D[n][m];
@@ -162,10 +162,10 @@ public class EditDistanceDouble implements SequenceDistanceMeasurerDouble {
   private double[][] initD(int n, int m) {
     double[][] D = new double[n + 1][m + 1];
     for (int i = 1; i <= n; i++) {
-      D[i][0] = D[i - 1][0] + delete_d;
+      D[i][0] = D[i - 1][0] + deleteCost;
     }
     for (int j = 1; j <= m; j++) {
-      D[0][j] = D[0][j - 1] + insert_d;
+      D[0][j] = D[0][j - 1] + insertCost;
     }
     return D;
   }

--- a/src/main/java/org/cicirello/sequences/distance/EditDistanceDouble.java
+++ b/src/main/java/org/cicirello/sequences/distance/EditDistanceDouble.java
@@ -79,109 +79,78 @@ public class EditDistanceDouble implements SequenceDistanceMeasurerDouble {
 
   @Override
   public final double distancef(int[] s1, int[] s2) {
-    return distancef(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_d);
+    return distancef(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
   @Override
   public final double distancef(long[] s1, long[] s2) {
-    return distancef(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_d);
+    return distancef(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
   @Override
   public final double distancef(short[] s1, short[] s2) {
-    return distancef(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_d);
+    return distancef(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
   @Override
   public final double distancef(byte[] s1, byte[] s2) {
-    return distancef(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_d);
+    return distancef(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
   @Override
   public final double distancef(char[] s1, char[] s2) {
-    return distancef(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_d);
+    return distancef(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
   @Override
   public final double distancef(boolean[] s1, boolean[] s2) {
-    return distancef(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_d);
+    return distancef(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
   @Override
   public final double distancef(double[] s1, double[] s2) {
-    return distancef(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_d);
+    return distancef(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
   @Override
   public final double distancef(float[] s1, float[] s2) {
-    return distancef(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i] == s2[j] ? costIfSame : costIfSame + change_d);
+    return distancef(s1.length, s2.length, (i, j) -> s1[i] == s2[j]);
   }
 
   @Override
   public final double distancef(String s1, String s2) {
-    return distancef(
-        s1.length(),
-        s2.length(),
-        (i, j, costIfSame) -> s1.charAt(i) == s2.charAt(j) ? costIfSame : costIfSame + change_d);
+    return distancef(s1.length(), s2.length(), (i, j) -> s1.charAt(i) == s2.charAt(j));
   }
 
   @Override
   public final double distancef(Object[] s1, Object[] s2) {
-    return distancef(
-        s1.length,
-        s2.length,
-        (i, j, costIfSame) -> s1[i].equals(s2[j]) ? costIfSame : costIfSame + change_d);
+    return distancef(s1.length, s2.length, (i, j) -> s1[i].equals(s2[j]));
   }
 
   @Override
   public final <T> double distancef(List<T> s1, List<T> s2) {
-    return distancef(s1.toArray(), s2.toArray());
+    return distancef(s1.size(), s2.size(), (i, j) -> s1.get(i).equals(s2.get(j)));
   }
 
   @FunctionalInterface
-  private interface ChangeCost {
+  private interface Equals {
     /**
-     * Computes cost of change.
+     * Checks if elements are the same.
      *
      * @param i Index into first sequence.
      * @param j Index into second sequence.
-     * @param costIfSame The cost if the elements are the same.
-     * @return Cost for a change.
+     * @return true if and only if the corresponding elements are equal.
      */
-    double apply(int i, int j, double valueIfSame);
+    boolean same(int i, int j);
   }
 
-  private double distancef(int n, int m, ChangeCost coster) {
+  private double distancef(int n, int m, Equals compare) {
     double[][] D = initD(n, m);
     for (int i = 1; i <= n; i++) {
       for (int j = 1; j <= m; j++) {
         D[i][j] =
             min(
-                coster.apply(i - 1, j - 1, D[i - 1][j - 1]),
+                compare.same(i - 1, j - 1) ? D[i - 1][j - 1] : D[i - 1][j - 1] + change_d,
                 D[i - 1][j] + delete_d,
                 D[i][j - 1] + insert_d);
       }
@@ -201,7 +170,6 @@ public class EditDistanceDouble implements SequenceDistanceMeasurerDouble {
   }
 
   private double min(double m1, double m2, double m3) {
-    if (m2 < m1) m1 = m2;
-    return m3 < m1 ? m3 : m1;
+    return Math.min(m1 < m2 ? m1 : m2, m3);
   }
 }

--- a/src/main/java/org/cicirello/sequences/distance/EditDistanceDouble.java
+++ b/src/main/java/org/cicirello/sequences/distance/EditDistanceDouble.java
@@ -70,8 +70,9 @@ public class EditDistanceDouble implements SequenceDistanceMeasurerDouble {
    * @throws IllegalArgumentException if any of the costs are negative.
    */
   public EditDistanceDouble(double insertCost, double deleteCost, double changeCost) {
-    if (insertCost < 0.0 || deleteCost < 0.0 || changeCost < 0.0)
+    if (insertCost < 0.0 || deleteCost < 0.0 || changeCost < 0.0) {
       throw new IllegalArgumentException("Costs must be non-negative.");
+    }
     insert_d = insertCost;
     delete_d = deleteCost;
     change_d = changeCost;

--- a/src/test/java/org/cicirello/permutations/distance/EditDistanceTests.java
+++ b/src/test/java/org/cicirello/permutations/distance/EditDistanceTests.java
@@ -30,6 +30,17 @@ import org.junit.jupiter.api.*;
 public class EditDistanceTests extends SharedTestForPermutationDistanceDouble {
 
   @Test
+  public void testEditDistanceExceptions() {
+    IllegalArgumentException illegal =
+        assertThrows(IllegalArgumentException.class, () -> new EditDistance(-1, 0, 0));
+    illegal = assertThrows(IllegalArgumentException.class, () -> new EditDistance(0, -1, 0));
+    illegal = assertThrows(IllegalArgumentException.class, () -> new EditDistance(0, 0, -1));
+    illegal = assertThrows(IllegalArgumentException.class, () -> new EditDistance(-0.01, 0, 0));
+    illegal = assertThrows(IllegalArgumentException.class, () -> new EditDistance(0, -0.01, 0));
+    illegal = assertThrows(IllegalArgumentException.class, () -> new EditDistance(0, 0, -0.01));
+  }
+
+  @Test
   public void testIdenticalPermutations() {
     EditDistance d = new EditDistance();
     identicalPermutationsDouble(d);

--- a/src/test/java/org/cicirello/sequences/distance/EditDistanceDoubleTests.java
+++ b/src/test/java/org/cicirello/sequences/distance/EditDistanceDoubleTests.java
@@ -25,15 +25,21 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.concurrent.ThreadLocalRandom;
 import org.junit.jupiter.api.*;
 
-/** JUnit tests for EditDistance. */
-public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
+/** JUnit tests for EditDistanceDouble. */
+public class EditDistanceDoubleTests extends InternalTestHelpersSequenceDistance {
 
   @Test
-  public void testEditDistanceExceptions() {
+  public void testEditDistanceDoubleExceptions() {
     IllegalArgumentException illegal =
-        assertThrows(IllegalArgumentException.class, () -> new EditDistance(-1, 0, 0));
-    illegal = assertThrows(IllegalArgumentException.class, () -> new EditDistance(0, -1, 0));
-    illegal = assertThrows(IllegalArgumentException.class, () -> new EditDistance(0, 0, -1));
+        assertThrows(IllegalArgumentException.class, () -> new EditDistanceDouble(-1, 0, 0));
+    illegal = assertThrows(IllegalArgumentException.class, () -> new EditDistanceDouble(0, -1, 0));
+    illegal = assertThrows(IllegalArgumentException.class, () -> new EditDistanceDouble(0, 0, -1));
+    illegal =
+        assertThrows(IllegalArgumentException.class, () -> new EditDistanceDouble(-0.01, 0, 0));
+    illegal =
+        assertThrows(IllegalArgumentException.class, () -> new EditDistanceDouble(0, -0.01, 0));
+    illegal =
+        assertThrows(IllegalArgumentException.class, () -> new EditDistanceDouble(0, 0, -0.01));
   }
 
   @Test
@@ -42,15 +48,11 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
       "a", "b", "a", "c", "a", "d", "a", "e", "a", "f", "a", "h", "a", "i", "a", "j", "a"
     };
     String[] s2 = {"k", "a", "m", "n", "o", "p", "a", "l", "a", "a", "q", "a", "a", "a", "a"};
-    EditDistance d = new EditDistance(1, 1, 2);
-    assertEquals(16, d.distance(s1, s2));
+    EditDistanceDouble d = new EditDistanceDouble(1, 1, 2);
     assertEquals(16.0, d.distancef(s1, s2));
-    assertEquals(16, d.distance(toList(s1), toList(s2)));
     assertEquals(16.0, d.distancef(toList(s1), toList(s2)));
-    d = new EditDistance(3, 3, 6);
-    assertEquals(48, d.distance(s1, s2));
+    d = new EditDistanceDouble(3, 3, 6);
     assertEquals(48.0, d.distancef(s1, s2));
-    assertEquals(48, d.distance(toList(s1), toList(s2)));
     assertEquals(48.0, d.distancef(toList(s1), toList(s2)));
 
     String[] s3 = {
@@ -61,13 +63,11 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
       "b", "b", "b", "b", "b", "b", "c", "d", "e", "f", "b", "b", "b", "b", "b", "b", "c", "d", "e",
       "f", "b", "b", "b", "b", "b"
     };
-    d = new EditDistance(2, 2, 3);
-    assertEquals(45, d.distance(s3, s4));
+    d = new EditDistanceDouble(2, 2, 3);
     assertEquals(45.0, d.distancef(s3, s4));
-    assertEquals(45, d.distance(toList(s3), toList(s4)));
     assertEquals(45.0, d.distancef(toList(s3), toList(s4)));
 
-    d = new EditDistance(3, 3, 6);
+    d = new EditDistanceDouble(3, 3, 6);
     NonComparable[] c1 = new NonComparable[17];
     for (int i = 0; i < 17; i++) {
       c1[i] = (i % 2) == 0 ? new NonComparable(0) : new NonComparable(i);
@@ -76,52 +76,53 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
     for (int i = 0; i < 16; i++) {
       c2[i] = (i % 2 == 0) ? new NonComparable(100 + i) : new NonComparable(0);
     }
-    assertEquals(51, d.distance(c1, c2));
-    assertEquals(51, d.distance(toList(c1), toList(c2)));
+    assertEquals(51, d.distancef(c1, c2));
+    assertEquals(51, d.distancef(toList(c1), toList(c2)));
   }
 
   @Test
   public void testIdentical() {
-    EditDistance d = new EditDistance(1, 2, 10);
-    identicalSequences(d);
+    EditDistanceDouble d = new EditDistanceDouble(1, 2, 10);
     identicalSequencesD(d);
-    d = new EditDistance(2, 1, 10);
-    identicalSequences(d);
+    d = new EditDistanceDouble(1.0, 2.0, 10.0);
     identicalSequencesD(d);
-    d = new EditDistance(3, 2, 1);
-    identicalSequences(d);
+    d = new EditDistanceDouble(2, 1, 10);
     identicalSequencesD(d);
-    d = new EditDistance(4, 5, 2);
-    identicalSequences(d);
+    d = new EditDistanceDouble(3, 2, 1);
+    identicalSequencesD(d);
+    d = new EditDistanceDouble(4, 5, 2);
+    identicalSequencesD(d);
+    d = new EditDistanceDouble(4.2, 5.2, 2.2);
+    identicalSequencesD(d);
+    d = new EditDistanceDouble(3.2, 2.2, 1.2);
+    identicalSequencesD(d);
+    d = new EditDistanceDouble(2.2, 1.2, 10.2);
+    identicalSequencesD(d);
+    d = new EditDistanceDouble(1.2, 2.2, 10.2);
     identicalSequencesD(d);
   }
 
   @Test
-  public void testEditDistance() {
+  public void testEditDistanceDouble() {
     int cost_i = 1;
     int cost_d = 1;
     // lcs of next pair is 8... lengths 17 and 15
     String s1 = "abacadaeafahaiaja";
     String s2 = "kamnopalaaqaaaa";
-    EditDistance d = new EditDistance(cost_i, cost_d, cost_i + cost_d);
-    assertEquals(16, d.distance(s1, s2));
+    EditDistanceDouble d = new EditDistanceDouble(cost_i, cost_d, cost_i + cost_d);
     assertEquals(16.0, d.distancef(s1, s2));
     char[] a1 = s1.toCharArray();
     char[] a2 = s2.toCharArray();
-    assertEquals(16, d.distance(a1, a2));
     assertEquals(16.0, d.distancef(a1, a2));
     cost_i = 3;
     cost_d = 3;
-    EditDistance d2 = new EditDistance(cost_i, cost_d, cost_i + cost_d);
-    assertEquals(48, d2.distance(s1, s2));
+    EditDistanceDouble d2 = new EditDistanceDouble(cost_i, cost_d, cost_i + cost_d);
     assertEquals(48.0, d2.distancef(s1, s2));
     {
       boolean[] b1 = {true, false, true, false, true, false, true, true, true, true, true, true};
       boolean[] b2 = {false, false, true, true, true, false, false, false};
       // lcs is 5... lengths are 12 and 8
-      assertEquals(10, d.distance(b1, b2));
       assertEquals(10.0, d.distancef(b1, b2));
-      assertEquals(30, d2.distance(b1, b2));
       assertEquals(30.0, d2.distancef(b1, b2));
     }
     { // int
@@ -133,9 +134,7 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
       for (int i = 0; i < b2.length; i++) {
         b2[i] = a2[i];
       }
-      assertEquals(16, d.distance(b1, b2));
       assertEquals(16.0, d.distancef(b1, b2));
-      assertEquals(48, d2.distance(b1, b2));
       assertEquals(48.0, d2.distancef(b1, b2));
     }
     { // long
@@ -147,9 +146,7 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
       for (int i = 0; i < b2.length; i++) {
         b2[i] = a2[i];
       }
-      assertEquals(16, d.distance(b1, b2));
       assertEquals(16.0, d.distancef(b1, b2));
-      assertEquals(48, d2.distance(b1, b2));
       assertEquals(48.0, d2.distancef(b1, b2));
     }
     { // short
@@ -161,9 +158,7 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
       for (int i = 0; i < b2.length; i++) {
         b2[i] = (short) a2[i];
       }
-      assertEquals(16, d.distance(b1, b2));
       assertEquals(16.0, d.distancef(b1, b2));
-      assertEquals(48, d2.distance(b1, b2));
       assertEquals(48.0, d2.distancef(b1, b2));
     }
     { // byte
@@ -175,9 +170,7 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
       for (int i = 0; i < b2.length; i++) {
         b2[i] = (byte) a2[i];
       }
-      assertEquals(16, d.distance(b1, b2));
       assertEquals(16.0, d.distancef(b1, b2));
-      assertEquals(48, d2.distance(b1, b2));
       assertEquals(48.0, d2.distancef(b1, b2));
     }
     { // double
@@ -189,9 +182,7 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
       for (int i = 0; i < b2.length; i++) {
         b2[i] = a2[i];
       }
-      assertEquals(16, d.distance(b1, b2));
       assertEquals(16.0, d.distancef(b1, b2));
-      assertEquals(48, d2.distance(b1, b2));
       assertEquals(48.0, d2.distancef(b1, b2));
     }
     { // float
@@ -203,9 +194,7 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
       for (int i = 0; i < b2.length; i++) {
         b2[i] = a2[i];
       }
-      assertEquals(16, d.distance(b1, b2));
       assertEquals(16.0, d.distancef(b1, b2));
-      assertEquals(48, d2.distance(b1, b2));
       assertEquals(48.0, d2.distancef(b1, b2));
     }
 
@@ -214,12 +203,10 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
     cost_i = 2;
     cost_d = 2;
     int cost_c = 3;
-    d = new EditDistance(cost_i, cost_d, cost_c);
-    assertEquals(45, d.distance(s1, s2));
+    d = new EditDistanceDouble(cost_i, cost_d, cost_c);
     assertEquals(45.0, d.distancef(s1, s2));
     a1 = s1.toCharArray();
     a2 = s2.toCharArray();
-    assertEquals(45, d.distance(a1, a2));
     assertEquals(45.0, d.distancef(a1, a2));
     { // int
       int[] b1 = new int[a1.length];
@@ -230,7 +217,6 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
       for (int i = 0; i < b2.length; i++) {
         b2[i] = a2[i];
       }
-      assertEquals(45, d.distance(b1, b2));
       assertEquals(45.0, d.distancef(b1, b2));
     }
     { // long
@@ -242,7 +228,6 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
       for (int i = 0; i < b2.length; i++) {
         b2[i] = a2[i];
       }
-      assertEquals(45, d.distance(b1, b2));
       assertEquals(45.0, d.distancef(b1, b2));
     }
     { // short
@@ -254,7 +239,6 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
       for (int i = 0; i < b2.length; i++) {
         b2[i] = (short) a2[i];
       }
-      assertEquals(45, d.distance(b1, b2));
       assertEquals(45.0, d.distancef(b1, b2));
     }
     { // byte
@@ -266,7 +250,6 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
       for (int i = 0; i < b2.length; i++) {
         b2[i] = (byte) a2[i];
       }
-      assertEquals(45, d.distance(b1, b2));
       assertEquals(45.0, d.distancef(b1, b2));
     }
     { // double
@@ -278,7 +261,6 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
       for (int i = 0; i < b2.length; i++) {
         b2[i] = a2[i];
       }
-      assertEquals(45, d.distance(b1, b2));
       assertEquals(45.0, d.distancef(b1, b2));
     }
     { // float
@@ -290,9 +272,14 @@ public class EditDistanceTests extends InternalTestHelpersSequenceDistance {
       for (int i = 0; i < b2.length; i++) {
         b2[i] = a2[i];
       }
-      assertEquals(45, d.distance(b1, b2));
       assertEquals(45.0, d.distancef(b1, b2));
     }
+    EditDistanceDouble dist1 = new EditDistanceDouble(1.1, 2.0, 2.0);
+    EditDistanceDouble dist2 = new EditDistanceDouble(2.0, 1.1, 2.0);
+    EditDistanceDouble dist3 = new EditDistanceDouble(2.0, 2.0, 1.1);
+    assertEquals(1.1, dist1.distancef("a", "ab"));
+    assertEquals(1.1, dist2.distancef("ab", "a"));
+    assertEquals(1.1, dist3.distancef("a", "b"));
   }
 
   private void identicalSequencesD(SequenceDistanceMeasurerDouble d) {


### PR DESCRIPTION
## Summary
Refactored to improve code quality and to perform minor optimizations of the following classes:
* org.cicirello.permutations.distance.EditDistance
* org.cicirello.sequences.distance.EditDistance
* org.cicirello.sequences.distance.EditDistanceDouble

Also removed the previously deprecated (in v5.1.0) constructor `org.cicirello.sequences.distance.EditDistance(double, double, double)`. To compute edit distance with double-valued costs for arrays and other sequences, use the existing `EditDistanceDouble` class instead. This does not impact the class with the same name that computes edit distance for permutations (i.e., the `org.cicirello.permutations.distance.EditDistance` class still accepts doubles for the costs).

**Breaking Changes**: Due to breaking changes, the next release will be a major release (see the Removed section below for details). Timing of that major release will likely be in the Fall of 2023 to coincide with the planned transition to Java 21 upon its release.

## Closing Issues
Closes #346 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
