### PR TITLE
Improvements to SequenceSampler implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Breaking Changes**: Due to breaking changes, the next release will be a major release (see the Removed section below for details). Timing of that major release will likely be in the Fall of 2023 to coincide with the planned transition to Java 21 upon its release.
 
 ### Added
+* Seeded constructors added to SequenceReservoirSampler, SequencePoolSampler, SequenceInsertionSampler, SequenceCompositeSampler.
 
 ### Changed
 * Refactored to improve code quality and to perform minor optimizations of the following classes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * org.cicirello.permutations.distance.EditDistance
   * org.cicirello.sequences.distance.EditDistance
   * org.cicirello.sequences.distance.EditDistanceDouble
+* Refactored to improve code quality and to optimize SequenceReservoirSampler, SequencePoolSampler, SequenceInsertionSampler, SequenceCompositeSampler.
 
 ### Deprecated
 
@@ -25,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed default method implementations in SequenceSampler interface (all interface methods now implemented in the implementing classes).
 
 ### Fixed
-* SequenceSampler method implementations with probability p of sampling an element fixed to always use specified randomness source (previously incorrectly used default randomness source on some calls).
+* Classes implementing SequenceSampler interface: methods with probability p of sampling an element fixed to always use specified randomness source (previously incorrectly used default randomness source on some calls).
 
 ### Dependencies
 * Bump rho-mu from 3.1.0 to 3.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed the previously deprecated (in v5.1.0) constructor `org.cicirello.sequences.distance.EditDistance(double, double, double)`. To compute edit distance with double-valued costs for arrays and other sequences, use the existing `EditDistanceDouble` class instead. This does not impact the class with the same name that computes edit distance for permutations (i.e., the `org.cicirello.permutations.distance.EditDistance` class still accepts doubles for the costs).
 
 ### Fixed
+* SequenceSampler static method implementations with probability p of element inclusion and randomness source r fixed to always use r as randomness source (previously incorrectly used default randomness source on some calls).
 
 ### Dependencies
 * Bump rho-mu from 3.1.0 to 3.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 * Removed the previously deprecated (in v5.1.0) constructor `org.cicirello.sequences.distance.EditDistance(double, double, double)`. To compute edit distance with double-valued costs for arrays and other sequences, use the existing `EditDistanceDouble` class instead. This does not impact the class with the same name that computes edit distance for permutations (i.e., the `org.cicirello.permutations.distance.EditDistance` class still accepts doubles for the costs).
+* Removed default method implementations in SequenceSampler interface (all interface methods now implemented in the implementing classes).
 
 ### Fixed
 * SequenceSampler method implementations with probability p of sampling an element fixed to always use specified randomness source (previously incorrectly used default randomness source on some calls).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Breaking Changes**: Due to breaking changes, the next release will be a major release (see the Removed section below for details). Timing of that major release will likely be in the Fall of 2023 to coincide with the planned transition to Java 21 upon its release.
 
 ### Added
+* SequenceSampler.getDefault() method for creating an instance of the default implementation of SequenceSampler.
+* SequenceSampler.getDefault(RandomGenerator) method for creating an instance of the default implementation of SequenceSampler from a given source of randomness.
+* SequenceSampler.getDefault(seed) method for creating an instance of the default implementation of SequenceSampler, specifying a seed for the random number generator.
 * Seeded constructors added to SequenceReservoirSampler, SequencePoolSampler, SequenceInsertionSampler, SequenceCompositeSampler.
 * Default constructors added to SequenceReservoirSampler, SequencePoolSampler, SequenceInsertionSampler, SequenceCompositeSampler.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed the previously deprecated (in v5.1.0) constructor `org.cicirello.sequences.distance.EditDistance(double, double, double)`. To compute edit distance with double-valued costs for arrays and other sequences, use the existing `EditDistanceDouble` class instead. This does not impact the class with the same name that computes edit distance for permutations (i.e., the `org.cicirello.permutations.distance.EditDistance` class still accepts doubles for the costs).
 
 ### Fixed
-* SequenceSampler static method implementations with probability p of element inclusion and randomness source r fixed to always use r as randomness source (previously incorrectly used default randomness source on some calls).
+* SequenceSampler method implementations with probability p of sampling an element fixed to always use specified randomness source (previously incorrectly used default randomness source on some calls).
 
 ### Dependencies
 * Bump rho-mu from 3.1.0 to 3.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Seeded constructors added to SequenceReservoirSampler, SequencePoolSampler, SequenceInsertionSampler, SequenceCompositeSampler.
+* Default constructors added to SequenceReservoirSampler, SequencePoolSampler, SequenceInsertionSampler, SequenceCompositeSampler.
 
 ### Changed
 * Refactored to improve code quality and to perform minor optimizations of the following classes:

--- a/src/main/java/org/cicirello/sequences/SequenceCompositeSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceCompositeSampler.java
@@ -77,6 +77,15 @@ public final class SequenceCompositeSampler implements SequenceSampler {
     reservoir = new SequenceReservoirSampler(this.r, true);
   }
 
+  /** Constructs a sampler with a default source of randomness. */
+  public SequenceCompositeSampler() {
+    this.r = new EnhancedRandomGenerator();
+
+    insertion = new SequenceInsertionSampler(this.r, true);
+    pool = new SequencePoolSampler(this.r, true);
+    reservoir = new SequenceReservoirSampler(this.r, true);
+  }
+
   /**
    * {@inheritDoc}
    *

--- a/src/main/java/org/cicirello/sequences/SequenceCompositeSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceCompositeSampler.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -165,7 +165,7 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static int[] sample(int[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -179,7 +179,7 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static long[] sample(long[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -193,7 +193,7 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static short[] sample(short[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -207,7 +207,7 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static byte[] sample(byte[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -221,7 +221,7 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static double[] sample(double[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -235,7 +235,7 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static float[] sample(float[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -249,7 +249,7 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static char[] sample(char[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -263,7 +263,7 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static char[] sample(String source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length(), p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length(), p, r), null, r);
   }
 
   /**
@@ -278,7 +278,7 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static <T> T[] sample(T[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**

--- a/src/main/java/org/cicirello/sequences/SequenceCompositeSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceCompositeSampler.java
@@ -65,6 +65,19 @@ public final class SequenceCompositeSampler implements SequenceSampler {
   }
 
   /**
+   * Constructs a sampler seeding the internal random number generator as specified.
+   *
+   * @param seed The seed for the random number generator
+   */
+  public SequenceCompositeSampler(long seed) {
+    this.r = new EnhancedRandomGenerator(seed);
+
+    insertion = new SequenceInsertionSampler(this.r, true);
+    pool = new SequencePoolSampler(this.r, true);
+    reservoir = new SequenceReservoirSampler(this.r, true);
+  }
+
+  /**
    * {@inheritDoc}
    *
    * @throws IllegalArgumentException if k &gt; source.length

--- a/src/main/java/org/cicirello/sequences/SequenceCompositeSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceCompositeSampler.java
@@ -22,6 +22,7 @@
 package org.cicirello.sequences;
 
 import java.util.random.RandomGenerator;
+import org.cicirello.math.rand.EnhancedRandomGenerator;
 import org.cicirello.math.rand.RandomVariates;
 
 /**
@@ -44,7 +45,7 @@ import org.cicirello.math.rand.RandomVariates;
  */
 public final class SequenceCompositeSampler implements SequenceSampler {
 
-  private final RandomGenerator r;
+  private final EnhancedRandomGenerator r;
 
   /**
    * Constructs a sampler wrapping a RandomGenerator used as the source of randomness.
@@ -52,7 +53,7 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @param r The source of randomness.
    */
   public SequenceCompositeSampler(RandomGenerator r) {
-    this.r = r;
+    this.r = new EnhancedRandomGenerator(r);
   }
 
   /**
@@ -156,47 +157,47 @@ public final class SequenceCompositeSampler implements SequenceSampler {
 
   @Override
   public int[] nextSample(int[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public long[] nextSample(long[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public short[] nextSample(short[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public byte[] nextSample(byte[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public double[] nextSample(double[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public float[] nextSample(float[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public char[] nextSample(char[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public char[] nextSample(String source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length(), p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length(), p), null);
   }
 
   @Override
   public <T> T[] nextSample(T[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   /**

--- a/src/main/java/org/cicirello/sequences/SequenceCompositeSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceCompositeSampler.java
@@ -154,6 +154,51 @@ public final class SequenceCompositeSampler implements SequenceSampler {
     return sample(source, k, target, r);
   }
 
+  @Override
+  public int[] nextSample(int[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public long[] nextSample(long[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public short[] nextSample(short[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public byte[] nextSample(byte[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public double[] nextSample(double[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public float[] nextSample(float[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public char[] nextSample(char[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public char[] nextSample(String source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length(), p, r), null, r);
+  }
+
+  @Override
+  public <T> T[] nextSample(T[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
   /**
    * Generates a random sample, without replacement, from a given source array with a specified
    * probability of an element's inclusion in the sample.

--- a/src/main/java/org/cicirello/sequences/SequenceCompositeSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceCompositeSampler.java
@@ -45,6 +45,10 @@ import org.cicirello.math.rand.RandomVariates;
  */
 public final class SequenceCompositeSampler implements SequenceSampler {
 
+  private final SequenceInsertionSampler insertion;
+  private final SequencePoolSampler pool;
+  private final SequenceReservoirSampler reservoir;
+
   private final EnhancedRandomGenerator r;
 
   /**
@@ -54,6 +58,10 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    */
   public SequenceCompositeSampler(RandomGenerator r) {
     this.r = new EnhancedRandomGenerator(r);
+
+    insertion = new SequenceInsertionSampler(this.r, true);
+    pool = new SequencePoolSampler(this.r, true);
+    reservoir = new SequenceReservoirSampler(this.r, true);
   }
 
   /**
@@ -64,7 +72,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    */
   @Override
   public int[] nextSample(int[] source, int k, int[] target) {
-    return sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return reservoir.nextSample(source, k, target);
+    }
+    if (k * k >= source.length) {
+      return pool.nextSample(source, k, target);
+    }
+    return insertion.nextSample(source, k, target);
   }
 
   /**
@@ -75,7 +89,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    */
   @Override
   public long[] nextSample(long[] source, int k, long[] target) {
-    return sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return reservoir.nextSample(source, k, target);
+    }
+    if (k * k >= source.length) {
+      return pool.nextSample(source, k, target);
+    }
+    return insertion.nextSample(source, k, target);
   }
 
   /**
@@ -86,7 +106,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    */
   @Override
   public short[] nextSample(short[] source, int k, short[] target) {
-    return sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return reservoir.nextSample(source, k, target);
+    }
+    if (k * k >= source.length) {
+      return pool.nextSample(source, k, target);
+    }
+    return insertion.nextSample(source, k, target);
   }
 
   /**
@@ -97,7 +123,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    */
   @Override
   public byte[] nextSample(byte[] source, int k, byte[] target) {
-    return sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return reservoir.nextSample(source, k, target);
+    }
+    if (k * k >= source.length) {
+      return pool.nextSample(source, k, target);
+    }
+    return insertion.nextSample(source, k, target);
   }
 
   /**
@@ -108,7 +140,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    */
   @Override
   public double[] nextSample(double[] source, int k, double[] target) {
-    return sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return reservoir.nextSample(source, k, target);
+    }
+    if (k * k >= source.length) {
+      return pool.nextSample(source, k, target);
+    }
+    return insertion.nextSample(source, k, target);
   }
 
   /**
@@ -119,7 +157,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    */
   @Override
   public float[] nextSample(float[] source, int k, float[] target) {
-    return sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return reservoir.nextSample(source, k, target);
+    }
+    if (k * k >= source.length) {
+      return pool.nextSample(source, k, target);
+    }
+    return insertion.nextSample(source, k, target);
   }
 
   /**
@@ -130,7 +174,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    */
   @Override
   public char[] nextSample(char[] source, int k, char[] target) {
-    return sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return reservoir.nextSample(source, k, target);
+    }
+    if (k * k >= source.length) {
+      return pool.nextSample(source, k, target);
+    }
+    return insertion.nextSample(source, k, target);
   }
 
   /**
@@ -141,7 +191,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    */
   @Override
   public char[] nextSample(String source, int k, char[] target) {
-    return sample(source, k, target, r);
+    if (k + k >= source.length()) {
+      return reservoir.nextSample(source, k, target);
+    }
+    if (k * k >= source.length()) {
+      return pool.nextSample(source, k, target);
+    }
+    return insertion.nextSample(source, k, target);
   }
 
   /**
@@ -152,7 +208,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    */
   @Override
   public <T> T[] nextSample(T[] source, int k, T[] target) {
-    return sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return reservoir.nextSample(source, k, target);
+    }
+    if (k * k >= source.length) {
+      return pool.nextSample(source, k, target);
+    }
+    return insertion.nextSample(source, k, target);
   }
 
   @Override
@@ -341,10 +403,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @throws NegativeArraySizeException if k &lt; 0
    */
   public static int[] sample(int[] source, int k, int[] target, RandomGenerator r) {
-    if (k + k < source.length) {
-      if (k * k < source.length) return SequenceInsertionSampler.sample(source, k, target, r);
-      else return SequencePoolSampler.sample(source, k, target, r);
-    } else return SequenceReservoirSampler.sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return SequenceReservoirSampler.sample(source, k, target, r);
+    }
+    if (k * k >= source.length) {
+      return SequencePoolSampler.sample(source, k, target, r);
+    }
+    return SequenceInsertionSampler.sample(source, k, target, r);
   }
 
   /**
@@ -361,10 +426,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @throws NegativeArraySizeException if k &lt; 0
    */
   public static long[] sample(long[] source, int k, long[] target, RandomGenerator r) {
-    if (k + k < source.length) {
-      if (k * k < source.length) return SequenceInsertionSampler.sample(source, k, target, r);
-      else return SequencePoolSampler.sample(source, k, target, r);
-    } else return SequenceReservoirSampler.sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return SequenceReservoirSampler.sample(source, k, target, r);
+    }
+    if (k * k >= source.length) {
+      return SequencePoolSampler.sample(source, k, target, r);
+    }
+    return SequenceInsertionSampler.sample(source, k, target, r);
   }
 
   /**
@@ -381,10 +449,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @throws NegativeArraySizeException if k &lt; 0
    */
   public static short[] sample(short[] source, int k, short[] target, RandomGenerator r) {
-    if (k + k < source.length) {
-      if (k * k < source.length) return SequenceInsertionSampler.sample(source, k, target, r);
-      else return SequencePoolSampler.sample(source, k, target, r);
-    } else return SequenceReservoirSampler.sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return SequenceReservoirSampler.sample(source, k, target, r);
+    }
+    if (k * k >= source.length) {
+      return SequencePoolSampler.sample(source, k, target, r);
+    }
+    return SequenceInsertionSampler.sample(source, k, target, r);
   }
 
   /**
@@ -401,10 +472,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @throws NegativeArraySizeException if k &lt; 0
    */
   public static byte[] sample(byte[] source, int k, byte[] target, RandomGenerator r) {
-    if (k + k < source.length) {
-      if (k * k < source.length) return SequenceInsertionSampler.sample(source, k, target, r);
-      else return SequencePoolSampler.sample(source, k, target, r);
-    } else return SequenceReservoirSampler.sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return SequenceReservoirSampler.sample(source, k, target, r);
+    }
+    if (k * k >= source.length) {
+      return SequencePoolSampler.sample(source, k, target, r);
+    }
+    return SequenceInsertionSampler.sample(source, k, target, r);
   }
 
   /**
@@ -421,10 +495,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @throws NegativeArraySizeException if k &lt; 0
    */
   public static char[] sample(char[] source, int k, char[] target, RandomGenerator r) {
-    if (k + k < source.length) {
-      if (k * k < source.length) return SequenceInsertionSampler.sample(source, k, target, r);
-      else return SequencePoolSampler.sample(source, k, target, r);
-    } else return SequenceReservoirSampler.sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return SequenceReservoirSampler.sample(source, k, target, r);
+    }
+    if (k * k >= source.length) {
+      return SequencePoolSampler.sample(source, k, target, r);
+    }
+    return SequenceInsertionSampler.sample(source, k, target, r);
   }
 
   /**
@@ -458,10 +535,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @throws NegativeArraySizeException if k &lt; 0
    */
   public static double[] sample(double[] source, int k, double[] target, RandomGenerator r) {
-    if (k + k < source.length) {
-      if (k * k < source.length) return SequenceInsertionSampler.sample(source, k, target, r);
-      else return SequencePoolSampler.sample(source, k, target, r);
-    } else return SequenceReservoirSampler.sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return SequenceReservoirSampler.sample(source, k, target, r);
+    }
+    if (k * k >= source.length) {
+      return SequencePoolSampler.sample(source, k, target, r);
+    }
+    return SequenceInsertionSampler.sample(source, k, target, r);
   }
 
   /**
@@ -478,10 +558,13 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @throws NegativeArraySizeException if k &lt; 0
    */
   public static float[] sample(float[] source, int k, float[] target, RandomGenerator r) {
-    if (k + k < source.length) {
-      if (k * k < source.length) return SequenceInsertionSampler.sample(source, k, target, r);
-      else return SequencePoolSampler.sample(source, k, target, r);
-    } else return SequenceReservoirSampler.sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return SequenceReservoirSampler.sample(source, k, target, r);
+    }
+    if (k * k >= source.length) {
+      return SequencePoolSampler.sample(source, k, target, r);
+    }
+    return SequenceInsertionSampler.sample(source, k, target, r);
   }
 
   /**
@@ -499,9 +582,12 @@ public final class SequenceCompositeSampler implements SequenceSampler {
    * @throws NegativeArraySizeException if k &lt; 0
    */
   public static <T> T[] sample(T[] source, int k, T[] target, RandomGenerator r) {
-    if (k + k < source.length) {
-      if (k * k < source.length) return SequenceInsertionSampler.sample(source, k, target, r);
-      else return SequencePoolSampler.sample(source, k, target, r);
-    } else return SequenceReservoirSampler.sample(source, k, target, r);
+    if (k + k >= source.length) {
+      return SequenceReservoirSampler.sample(source, k, target, r);
+    }
+    if (k * k >= source.length) {
+      return SequencePoolSampler.sample(source, k, target, r);
+    }
+    return SequenceInsertionSampler.sample(source, k, target, r);
   }
 }

--- a/src/main/java/org/cicirello/sequences/SequenceInsertionSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceInsertionSampler.java
@@ -60,6 +60,15 @@ public final class SequenceInsertionSampler implements SequenceSampler {
   }
 
   /**
+   * Constructs a sampler seeding the internal random number generator as specified.
+   *
+   * @param seed The seed for the random number generator
+   */
+  public SequenceInsertionSampler(long seed) {
+    this.r = new EnhancedRandomGenerator(seed);
+  }
+
+  /**
    * package use only: creates an instance wrapping an existing EnhancedRandomGenerator
    *
    * @param r the source of randomness

--- a/src/main/java/org/cicirello/sequences/SequenceInsertionSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceInsertionSampler.java
@@ -157,6 +157,51 @@ public final class SequenceInsertionSampler implements SequenceSampler {
     return sample(source, k, target, r);
   }
 
+  @Override
+  public int[] nextSample(int[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public long[] nextSample(long[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public short[] nextSample(short[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public byte[] nextSample(byte[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public double[] nextSample(double[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public float[] nextSample(float[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public char[] nextSample(char[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public char[] nextSample(String source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length(), p, r), null, r);
+  }
+
+  @Override
+  public <T> T[] nextSample(T[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
   /**
    * Generates a random sample, without replacement, from a given source array with a specified
    * probability of an element's inclusion in the sample.

--- a/src/main/java/org/cicirello/sequences/SequenceInsertionSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceInsertionSampler.java
@@ -60,6 +60,17 @@ public final class SequenceInsertionSampler implements SequenceSampler {
   }
 
   /**
+   * package use only: creates an instance wrapping an existing EnhancedRandomGenerator
+   *
+   * @param r the source of randomness
+   * @param reserved currently does nothing, and only serves purpose of differentiating between this
+   *     internal constructor and the public constructor
+   */
+  SequenceInsertionSampler(EnhancedRandomGenerator r, boolean reserved) {
+    this.r = r;
+  }
+
+  /**
    * {@inheritDoc}
    *
    * @throws IllegalArgumentException if k &gt; source.length

--- a/src/main/java/org/cicirello/sequences/SequenceInsertionSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceInsertionSampler.java
@@ -168,7 +168,7 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static int[] sample(int[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -182,7 +182,7 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static long[] sample(long[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -196,7 +196,7 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static short[] sample(short[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -210,7 +210,7 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static byte[] sample(byte[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -224,7 +224,7 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static double[] sample(double[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -238,7 +238,7 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static float[] sample(float[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -252,7 +252,7 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static char[] sample(char[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -266,7 +266,7 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static char[] sample(String source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length(), p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length(), p, r), null, r);
   }
 
   /**
@@ -281,7 +281,7 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static <T> T[] sample(T[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**

--- a/src/main/java/org/cicirello/sequences/SequenceInsertionSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceInsertionSampler.java
@@ -22,6 +22,7 @@
 package org.cicirello.sequences;
 
 import java.util.random.RandomGenerator;
+import org.cicirello.math.rand.EnhancedRandomGenerator;
 import org.cicirello.math.rand.RandomSampler;
 import org.cicirello.math.rand.RandomVariates;
 import org.cicirello.util.ArrayMinimumLengthEnforcer;
@@ -47,7 +48,7 @@ import org.cicirello.util.ArrayMinimumLengthEnforcer;
  */
 public final class SequenceInsertionSampler implements SequenceSampler {
 
-  private final RandomGenerator r;
+  private final EnhancedRandomGenerator r;
 
   /**
    * Constructs a sampler wrapping a RandomGenerator used as the source of randomness.
@@ -55,7 +56,7 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    * @param r The source of randomness.
    */
   public SequenceInsertionSampler(RandomGenerator r) {
-    this.r = r;
+    this.r = new EnhancedRandomGenerator(r);
   }
 
   /**
@@ -66,7 +67,12 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    */
   @Override
   public int[] nextSample(int[] source, int k, int[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = r.sampleInsertion(source.length, k, target);
+    for (int i = 0; i < k; i++) {
+      target[i] = source[target[i]];
+    }
+    return target;
   }
 
   /**
@@ -77,7 +83,13 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    */
   @Override
   public long[] nextSample(long[] source, int k, long[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    int[] indexes = r.sampleInsertion(source.length, k, null);
+    for (int i = 0; i < k; i++) {
+      target[i] = source[indexes[i]];
+    }
+    return target;
   }
 
   /**
@@ -88,7 +100,13 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    */
   @Override
   public short[] nextSample(short[] source, int k, short[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    int[] indexes = r.sampleInsertion(source.length, k, null);
+    for (int i = 0; i < k; i++) {
+      target[i] = source[indexes[i]];
+    }
+    return target;
   }
 
   /**
@@ -99,7 +117,13 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    */
   @Override
   public byte[] nextSample(byte[] source, int k, byte[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    int[] indexes = r.sampleInsertion(source.length, k, null);
+    for (int i = 0; i < k; i++) {
+      target[i] = source[indexes[i]];
+    }
+    return target;
   }
 
   /**
@@ -110,7 +134,13 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    */
   @Override
   public double[] nextSample(double[] source, int k, double[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    int[] indexes = r.sampleInsertion(source.length, k, null);
+    for (int i = 0; i < k; i++) {
+      target[i] = source[indexes[i]];
+    }
+    return target;
   }
 
   /**
@@ -121,7 +151,13 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    */
   @Override
   public float[] nextSample(float[] source, int k, float[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    int[] indexes = r.sampleInsertion(source.length, k, null);
+    for (int i = 0; i < k; i++) {
+      target[i] = source[indexes[i]];
+    }
+    return target;
   }
 
   /**
@@ -132,7 +168,13 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    */
   @Override
   public char[] nextSample(char[] source, int k, char[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    int[] indexes = r.sampleInsertion(source.length, k, null);
+    for (int i = 0; i < k; i++) {
+      target[i] = source[indexes[i]];
+    }
+    return target;
   }
 
   /**
@@ -143,7 +185,7 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    */
   @Override
   public char[] nextSample(String source, int k, char[] target) {
-    return sample(source, k, target, r);
+    return nextSample(source.toCharArray(), k, target);
   }
 
   /**
@@ -154,52 +196,58 @@ public final class SequenceInsertionSampler implements SequenceSampler {
    */
   @Override
   public <T> T[] nextSample(T[] source, int k, T[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = SequenceSamplerUtils.allocateIfNecessary(source, k, target);
+    int[] indexes = r.sampleInsertion(source.length, k, null);
+    for (int i = 0; i < k; i++) {
+      target[i] = source[indexes[i]];
+    }
+    return target;
   }
 
   @Override
   public int[] nextSample(int[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public long[] nextSample(long[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public short[] nextSample(short[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public byte[] nextSample(byte[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public double[] nextSample(double[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public float[] nextSample(float[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public char[] nextSample(char[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public char[] nextSample(String source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length(), p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length(), p), null);
   }
 
   @Override
   public <T> T[] nextSample(T[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   /**

--- a/src/main/java/org/cicirello/sequences/SequenceInsertionSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceInsertionSampler.java
@@ -68,6 +68,11 @@ public final class SequenceInsertionSampler implements SequenceSampler {
     this.r = new EnhancedRandomGenerator(seed);
   }
 
+  /** Constructs a sampler with a default source of randomness. */
+  public SequenceInsertionSampler() {
+    this.r = new EnhancedRandomGenerator();
+  }
+
   /**
    * package use only: creates an instance wrapping an existing EnhancedRandomGenerator
    *

--- a/src/main/java/org/cicirello/sequences/SequencePoolSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequencePoolSampler.java
@@ -153,6 +153,51 @@ public final class SequencePoolSampler implements SequenceSampler {
     return sample(source, k, target, r);
   }
 
+  @Override
+  public int[] nextSample(int[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public long[] nextSample(long[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public short[] nextSample(short[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public byte[] nextSample(byte[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public double[] nextSample(double[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public float[] nextSample(float[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public char[] nextSample(char[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
+  @Override
+  public char[] nextSample(String source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length(), p, r), null, r);
+  }
+
+  @Override
+  public <T> T[] nextSample(T[] source, double p) {
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+  }
+
   /**
    * Generates a random sample, without replacement, from a given source array with a specified
    * probability of an element's inclusion in the sample.

--- a/src/main/java/org/cicirello/sequences/SequencePoolSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequencePoolSampler.java
@@ -56,6 +56,15 @@ public final class SequencePoolSampler implements SequenceSampler {
   }
 
   /**
+   * Constructs a sampler seeding the internal random number generator as specified.
+   *
+   * @param seed The seed for the random number generator
+   */
+  public SequencePoolSampler(long seed) {
+    this.r = new EnhancedRandomGenerator(seed);
+  }
+
+  /**
    * package use only: creates an instance wrapping an existing EnhancedRandomGenerator
    *
    * @param r the source of randomness

--- a/src/main/java/org/cicirello/sequences/SequencePoolSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequencePoolSampler.java
@@ -56,6 +56,17 @@ public final class SequencePoolSampler implements SequenceSampler {
   }
 
   /**
+   * package use only: creates an instance wrapping an existing EnhancedRandomGenerator
+   *
+   * @param r the source of randomness
+   * @param reserved currently does nothing, and only serves purpose of differentiating between this
+   *     internal constructor and the public constructor
+   */
+  SequencePoolSampler(EnhancedRandomGenerator r, boolean reserved) {
+    this.r = r;
+  }
+
+  /**
    * {@inheritDoc}
    *
    * @throws IllegalArgumentException if k &gt; source.length

--- a/src/main/java/org/cicirello/sequences/SequencePoolSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequencePoolSampler.java
@@ -23,6 +23,7 @@ package org.cicirello.sequences;
 
 import java.util.Arrays;
 import java.util.random.RandomGenerator;
+import org.cicirello.math.rand.EnhancedRandomGenerator;
 import org.cicirello.math.rand.RandomIndexer;
 import org.cicirello.math.rand.RandomVariates;
 import org.cicirello.util.ArrayMinimumLengthEnforcer;
@@ -43,7 +44,7 @@ import org.cicirello.util.ArrayMinimumLengthEnforcer;
  */
 public final class SequencePoolSampler implements SequenceSampler {
 
-  private final RandomGenerator r;
+  private final EnhancedRandomGenerator r;
 
   /**
    * Constructs a sampler wrapping a RandomGenerator used as the source of randomness.
@@ -51,7 +52,7 @@ public final class SequencePoolSampler implements SequenceSampler {
    * @param r The source of randomness.
    */
   public SequencePoolSampler(RandomGenerator r) {
-    this.r = r;
+    this.r = new EnhancedRandomGenerator(r);
   }
 
   /**
@@ -62,7 +63,17 @@ public final class SequencePoolSampler implements SequenceSampler {
    */
   @Override
   public int[] nextSample(int[] source, int k, int[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    int[] pool = source.clone();
+    int remaining = pool.length;
+    for (int i = 0; i < k; i++) {
+      int j = r.nextInt(remaining);
+      target[i] = pool[j];
+      remaining--;
+      pool[j] = pool[remaining];
+    }
+    return target;
   }
 
   /**
@@ -73,7 +84,17 @@ public final class SequencePoolSampler implements SequenceSampler {
    */
   @Override
   public long[] nextSample(long[] source, int k, long[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    long[] pool = source.clone();
+    int remaining = pool.length;
+    for (int i = 0; i < k; i++) {
+      int j = r.nextInt(remaining);
+      target[i] = pool[j];
+      remaining--;
+      pool[j] = pool[remaining];
+    }
+    return target;
   }
 
   /**
@@ -84,7 +105,17 @@ public final class SequencePoolSampler implements SequenceSampler {
    */
   @Override
   public short[] nextSample(short[] source, int k, short[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    short[] pool = source.clone();
+    int remaining = pool.length;
+    for (int i = 0; i < k; i++) {
+      int j = r.nextInt(remaining);
+      target[i] = pool[j];
+      remaining--;
+      pool[j] = pool[remaining];
+    }
+    return target;
   }
 
   /**
@@ -95,7 +126,17 @@ public final class SequencePoolSampler implements SequenceSampler {
    */
   @Override
   public byte[] nextSample(byte[] source, int k, byte[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    byte[] pool = source.clone();
+    int remaining = pool.length;
+    for (int i = 0; i < k; i++) {
+      int j = r.nextInt(remaining);
+      target[i] = pool[j];
+      remaining--;
+      pool[j] = pool[remaining];
+    }
+    return target;
   }
 
   /**
@@ -106,7 +147,17 @@ public final class SequencePoolSampler implements SequenceSampler {
    */
   @Override
   public double[] nextSample(double[] source, int k, double[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    double[] pool = source.clone();
+    int remaining = pool.length;
+    for (int i = 0; i < k; i++) {
+      int j = r.nextInt(remaining);
+      target[i] = pool[j];
+      remaining--;
+      pool[j] = pool[remaining];
+    }
+    return target;
   }
 
   /**
@@ -117,7 +168,17 @@ public final class SequencePoolSampler implements SequenceSampler {
    */
   @Override
   public float[] nextSample(float[] source, int k, float[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    float[] pool = source.clone();
+    int remaining = pool.length;
+    for (int i = 0; i < k; i++) {
+      int j = r.nextInt(remaining);
+      target[i] = pool[j];
+      remaining--;
+      pool[j] = pool[remaining];
+    }
+    return target;
   }
 
   /**
@@ -128,7 +189,17 @@ public final class SequencePoolSampler implements SequenceSampler {
    */
   @Override
   public char[] nextSample(char[] source, int k, char[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    char[] pool = source.clone();
+    int remaining = pool.length;
+    for (int i = 0; i < k; i++) {
+      int j = r.nextInt(remaining);
+      target[i] = pool[j];
+      remaining--;
+      pool[j] = pool[remaining];
+    }
+    return target;
   }
 
   /**
@@ -139,7 +210,7 @@ public final class SequencePoolSampler implements SequenceSampler {
    */
   @Override
   public char[] nextSample(String source, int k, char[] target) {
-    return sample(source, k, target, r);
+    return nextSample(source.toCharArray(), k, target);
   }
 
   /**
@@ -150,52 +221,62 @@ public final class SequencePoolSampler implements SequenceSampler {
    */
   @Override
   public <T> T[] nextSample(T[] source, int k, T[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = SequenceSamplerUtils.allocateIfNecessary(source, k, target);
+    T[] pool = Arrays.copyOf(source, source.length);
+    int remaining = pool.length;
+    for (int i = 0; i < k; i++) {
+      int j = r.nextInt(remaining);
+      target[i] = pool[j];
+      remaining--;
+      pool[j] = pool[remaining];
+    }
+    return target;
   }
 
   @Override
   public int[] nextSample(int[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public long[] nextSample(long[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public short[] nextSample(short[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public byte[] nextSample(byte[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public double[] nextSample(double[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public float[] nextSample(float[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public char[] nextSample(char[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public char[] nextSample(String source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length(), p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length(), p), null);
   }
 
   @Override
   public <T> T[] nextSample(T[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   /**

--- a/src/main/java/org/cicirello/sequences/SequencePoolSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequencePoolSampler.java
@@ -64,6 +64,11 @@ public final class SequencePoolSampler implements SequenceSampler {
     this.r = new EnhancedRandomGenerator(seed);
   }
 
+  /** Constructs a sampler with a default source of randomness. */
+  public SequencePoolSampler() {
+    this.r = new EnhancedRandomGenerator();
+  }
+
   /**
    * package use only: creates an instance wrapping an existing EnhancedRandomGenerator
    *

--- a/src/main/java/org/cicirello/sequences/SequencePoolSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequencePoolSampler.java
@@ -164,7 +164,7 @@ public final class SequencePoolSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static int[] sample(int[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -178,7 +178,7 @@ public final class SequencePoolSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static long[] sample(long[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -192,7 +192,7 @@ public final class SequencePoolSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static short[] sample(short[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -206,7 +206,7 @@ public final class SequencePoolSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static byte[] sample(byte[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -220,7 +220,7 @@ public final class SequencePoolSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static double[] sample(double[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -234,7 +234,7 @@ public final class SequencePoolSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static float[] sample(float[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -248,7 +248,7 @@ public final class SequencePoolSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static char[] sample(char[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -262,7 +262,7 @@ public final class SequencePoolSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static char[] sample(String source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length(), p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length(), p, r), null, r);
   }
 
   /**
@@ -277,7 +277,7 @@ public final class SequencePoolSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static <T> T[] sample(T[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**

--- a/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
@@ -53,6 +53,15 @@ public final class SequenceReservoirSampler implements SequenceSampler {
   }
 
   /**
+   * Constructs a sampler seeding the internal random number generator as specified.
+   *
+   * @param seed The seed for the random number generator
+   */
+  public SequenceReservoirSampler(long seed) {
+    this.r = new EnhancedRandomGenerator(seed);
+  }
+
+  /**
    * package use only: creates an instance wrapping an existing EnhancedRandomGenerator
    *
    * @param r the source of randomness

--- a/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
@@ -161,7 +161,7 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static int[] sample(int[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -175,7 +175,7 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static long[] sample(long[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -189,7 +189,7 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static short[] sample(short[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -203,7 +203,7 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static byte[] sample(byte[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -217,7 +217,7 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static double[] sample(double[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -231,7 +231,7 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static float[] sample(float[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -245,7 +245,7 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static char[] sample(char[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**
@@ -259,7 +259,7 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static char[] sample(String source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length(), p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length(), p, r), null, r);
   }
 
   /**
@@ -274,7 +274,7 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   public static <T> T[] sample(T[] source, double p, RandomGenerator r) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p), null, r);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**

--- a/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
@@ -150,6 +150,51 @@ public final class SequenceReservoirSampler implements SequenceSampler {
     return sample(source, k, target, r);
   }
 
+  @Override
+  public int[] nextSample(int[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+  }
+
+  @Override
+  public long[] nextSample(long[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+  }
+
+  @Override
+  public short[] nextSample(short[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+  }
+
+  @Override
+  public byte[] nextSample(byte[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+  }
+
+  @Override
+  public double[] nextSample(double[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+  }
+
+  @Override
+  public float[] nextSample(float[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+  }
+
+  @Override
+  public char[] nextSample(char[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+  }
+
+  @Override
+  public char[] nextSample(String source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length(), p, r), null);
+  }
+
+  @Override
+  public <T> T[] nextSample(T[] source, double p) {
+    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+  }
+
   /**
    * Generates a random sample, without replacement, from a given source array with a specified
    * probability of an element's inclusion in the sample.

--- a/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
@@ -53,6 +53,17 @@ public final class SequenceReservoirSampler implements SequenceSampler {
   }
 
   /**
+   * package use only: creates an instance wrapping an existing EnhancedRandomGenerator
+   *
+   * @param r the source of randomness
+   * @param reserved currently does nothing, and only serves purpose of differentiating between this
+   *     internal constructor and the public constructor
+   */
+  SequenceReservoirSampler(EnhancedRandomGenerator r, boolean reserved) {
+    this.r = r;
+  }
+
+  /**
    * {@inheritDoc}
    *
    * @throws IllegalArgumentException if k &gt; source.length

--- a/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
@@ -152,47 +152,47 @@ public final class SequenceReservoirSampler implements SequenceSampler {
 
   @Override
   public int[] nextSample(int[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   @Override
   public long[] nextSample(long[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   @Override
   public short[] nextSample(short[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   @Override
   public byte[] nextSample(byte[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   @Override
   public double[] nextSample(double[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   @Override
   public float[] nextSample(float[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   @Override
   public char[] nextSample(char[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   @Override
   public char[] nextSample(String source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length(), p, r), null);
+    return sample(source, RandomVariates.nextBinomial(source.length(), p, r), null, r);
   }
 
   @Override
   public <T> T[] nextSample(T[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p, r), null);
+    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
   }
 
   /**

--- a/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
@@ -22,6 +22,7 @@
 package org.cicirello.sequences;
 
 import java.util.random.RandomGenerator;
+import org.cicirello.math.rand.EnhancedRandomGenerator;
 import org.cicirello.math.rand.RandomIndexer;
 import org.cicirello.math.rand.RandomVariates;
 import org.cicirello.util.ArrayMinimumLengthEnforcer;
@@ -40,7 +41,7 @@ import org.cicirello.util.ArrayMinimumLengthEnforcer;
  */
 public final class SequenceReservoirSampler implements SequenceSampler {
 
-  private final RandomGenerator r;
+  private final EnhancedRandomGenerator r;
 
   /**
    * Constructs a sampler wrapping a RandomGenerator used as the source of randomness.
@@ -48,7 +49,7 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    * @param r The source of randomness.
    */
   public SequenceReservoirSampler(RandomGenerator r) {
-    this.r = r;
+    this.r = new EnhancedRandomGenerator(r);
   }
 
   /**
@@ -59,7 +60,16 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    */
   @Override
   public int[] nextSample(int[] source, int k, int[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    System.arraycopy(source, 0, target, 0, k);
+    for (int i = k; i < source.length; i++) {
+      int j = r.nextInt(i + 1);
+      if (j < k) {
+        target[j] = source[i];
+      }
+    }
+    return target;
   }
 
   /**
@@ -70,7 +80,16 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    */
   @Override
   public long[] nextSample(long[] source, int k, long[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    System.arraycopy(source, 0, target, 0, k);
+    for (int i = k; i < source.length; i++) {
+      int j = r.nextInt(i + 1);
+      if (j < k) {
+        target[j] = source[i];
+      }
+    }
+    return target;
   }
 
   /**
@@ -81,7 +100,16 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    */
   @Override
   public short[] nextSample(short[] source, int k, short[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    System.arraycopy(source, 0, target, 0, k);
+    for (int i = k; i < source.length; i++) {
+      int j = r.nextInt(i + 1);
+      if (j < k) {
+        target[j] = source[i];
+      }
+    }
+    return target;
   }
 
   /**
@@ -92,7 +120,16 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    */
   @Override
   public byte[] nextSample(byte[] source, int k, byte[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    System.arraycopy(source, 0, target, 0, k);
+    for (int i = k; i < source.length; i++) {
+      int j = r.nextInt(i + 1);
+      if (j < k) {
+        target[j] = source[i];
+      }
+    }
+    return target;
   }
 
   /**
@@ -103,7 +140,16 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    */
   @Override
   public double[] nextSample(double[] source, int k, double[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    System.arraycopy(source, 0, target, 0, k);
+    for (int i = k; i < source.length; i++) {
+      int j = r.nextInt(i + 1);
+      if (j < k) {
+        target[j] = source[i];
+      }
+    }
+    return target;
   }
 
   /**
@@ -114,7 +160,16 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    */
   @Override
   public float[] nextSample(float[] source, int k, float[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    System.arraycopy(source, 0, target, 0, k);
+    for (int i = k; i < source.length; i++) {
+      int j = r.nextInt(i + 1);
+      if (j < k) {
+        target[j] = source[i];
+      }
+    }
+    return target;
   }
 
   /**
@@ -125,7 +180,16 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    */
   @Override
   public char[] nextSample(char[] source, int k, char[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = ArrayMinimumLengthEnforcer.enforce(target, k);
+    System.arraycopy(source, 0, target, 0, k);
+    for (int i = k; i < source.length; i++) {
+      int j = r.nextInt(i + 1);
+      if (j < k) {
+        target[j] = source[i];
+      }
+    }
+    return target;
   }
 
   /**
@@ -136,7 +200,7 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    */
   @Override
   public char[] nextSample(String source, int k, char[] target) {
-    return sample(source, k, target, r);
+    return nextSample(source.toCharArray(), k, target);
   }
 
   /**
@@ -147,52 +211,61 @@ public final class SequenceReservoirSampler implements SequenceSampler {
    */
   @Override
   public <T> T[] nextSample(T[] source, int k, T[] target) {
-    return sample(source, k, target, r);
+    SequenceSamplerUtils.validateK(k, source.length);
+    target = SequenceSamplerUtils.allocateIfNecessary(source, k, target);
+    System.arraycopy(source, 0, target, 0, k);
+    for (int i = k; i < source.length; i++) {
+      int j = r.nextInt(i + 1);
+      if (j < k) {
+        target[j] = source[i];
+      }
+    }
+    return target;
   }
 
   @Override
   public int[] nextSample(int[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public long[] nextSample(long[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public short[] nextSample(short[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public byte[] nextSample(byte[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public double[] nextSample(double[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public float[] nextSample(float[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public char[] nextSample(char[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   @Override
   public char[] nextSample(String source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length(), p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length(), p), null);
   }
 
   @Override
   public <T> T[] nextSample(T[] source, double p) {
-    return sample(source, RandomVariates.nextBinomial(source.length, p, r), null, r);
+    return nextSample(source, r.nextBinomial(source.length, p), null);
   }
 
   /**

--- a/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceReservoirSampler.java
@@ -61,6 +61,11 @@ public final class SequenceReservoirSampler implements SequenceSampler {
     this.r = new EnhancedRandomGenerator(seed);
   }
 
+  /** Constructs a sampler with a default source of randomness. */
+  public SequenceReservoirSampler() {
+    this.r = new EnhancedRandomGenerator();
+  }
+
   /**
    * package use only: creates an instance wrapping an existing EnhancedRandomGenerator
    *

--- a/src/main/java/org/cicirello/sequences/SequenceSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceSampler.java
@@ -22,6 +22,7 @@
 package org.cicirello.sequences;
 
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.random.RandomGenerator;
 import org.cicirello.math.rand.RandomVariates;
 
 /**
@@ -241,6 +242,44 @@ public interface SequenceSampler {
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
   <T> T[] nextSample(T[] source, double p);
+
+  /**
+   * Gets an instance of the default SequenceSampler with a default source of randomness. The
+   * default is currently {@link SequenceCompositeSampler}, but this may change in future releases
+   * without notice, so no assumptions should be made concerning the specific SequenceSampler
+   * returned by this method.
+   *
+   * @return an instance of the default SequenceSampler
+   */
+  public static SequenceSampler getDefault() {
+    return new SequenceCompositeSampler();
+  }
+
+  /**
+   * Gets an instance of the default SequenceSampler given a specified source of randomness. The
+   * default is currently {@link SequenceCompositeSampler}, but this may change in future releases
+   * without notice, so no assumptions should be made concerning the specific SequenceSampler
+   * returned by this method.
+   *
+   * @param r The source of randomness.
+   * @return an instance of the default SequenceSampler
+   */
+  public static SequenceSampler getDefault(RandomGenerator r) {
+    return new SequenceCompositeSampler(r);
+  }
+
+  /**
+   * Gets an instance of the default SequenceSampler with a seed specified for the internal random
+   * number generator. The default is currently {@link SequenceCompositeSampler}, but this may
+   * change in future releases without notice, so no assumptions should be made concerning the
+   * specific SequenceSampler returned by this method.
+   *
+   * @param seed The seed for the random number generator
+   * @return an instance of the default SequenceSampler
+   */
+  public static SequenceSampler getDefault(long seed) {
+    return new SequenceCompositeSampler(seed);
+  }
 
   /**
    * Generates a random sample, without replacement, from a given source array with a specified

--- a/src/main/java/org/cicirello/sequences/SequenceSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceSampler.java
@@ -151,9 +151,7 @@ public interface SequenceSampler {
    *     source.length * p.
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
-  default int[] nextSample(int[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
-  }
+  int[] nextSample(int[] source, double p);
 
   /**
    * Generates a random sample, without replacement, from a given source array with a specified
@@ -164,9 +162,7 @@ public interface SequenceSampler {
    *     source.length * p.
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
-  default long[] nextSample(long[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
-  }
+  long[] nextSample(long[] source, double p);
 
   /**
    * Generates a random sample, without replacement, from a given source array with a specified
@@ -177,9 +173,7 @@ public interface SequenceSampler {
    *     source.length * p.
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
-  default short[] nextSample(short[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
-  }
+  short[] nextSample(short[] source, double p);
 
   /**
    * Generates a random sample, without replacement, from a given source array with a specified
@@ -190,9 +184,7 @@ public interface SequenceSampler {
    *     source.length * p.
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
-  default byte[] nextSample(byte[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
-  }
+  byte[] nextSample(byte[] source, double p);
 
   /**
    * Generates a random sample, without replacement, from a given source array with a specified
@@ -203,9 +195,7 @@ public interface SequenceSampler {
    *     source.length * p.
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
-  default double[] nextSample(double[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
-  }
+  double[] nextSample(double[] source, double p);
 
   /**
    * Generates a random sample, without replacement, from a given source array with a specified
@@ -216,9 +206,7 @@ public interface SequenceSampler {
    *     source.length * p.
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
-  default float[] nextSample(float[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
-  }
+  float[] nextSample(float[] source, double p);
 
   /**
    * Generates a random sample, without replacement, from a given source array with a specified
@@ -229,9 +217,7 @@ public interface SequenceSampler {
    *     source.length * p.
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
-  default char[] nextSample(char[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
-  }
+  char[] nextSample(char[] source, double p);
 
   /**
    * Generates a random sample, without replacement, from a given source String with a specified
@@ -242,9 +228,7 @@ public interface SequenceSampler {
    *     source.length() * p.
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
-  default char[] nextSample(String source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length(), p), null);
-  }
+  char[] nextSample(String source, double p);
 
   /**
    * Generates a random sample, without replacement, from a given source array with a specified
@@ -256,9 +240,7 @@ public interface SequenceSampler {
    *     source.length * p.
    * @return An array containing the sample, whose sample size is simply the length of the array.
    */
-  default <T> T[] nextSample(T[] source, double p) {
-    return nextSample(source, RandomVariates.nextBinomial(source.length, p), null);
-  }
+  <T> T[] nextSample(T[] source, double p);
 
   /**
    * Generates a random sample, without replacement, from a given source array with a specified

--- a/src/main/java/org/cicirello/sequences/SequenceSampler.java
+++ b/src/main/java/org/cicirello/sequences/SequenceSampler.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerByteTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerByteTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2019-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -35,6 +35,8 @@ public class SequenceSamplerByteTests {
     validateSamples(r::nextSample);
     r = new SequenceCompositeSampler(42);
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -42,6 +44,8 @@ public class SequenceSamplerByteTests {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceReservoirSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler();
     validateSamples(r::nextSample);
   }
 
@@ -51,6 +55,8 @@ public class SequenceSamplerByteTests {
     validateSamples(r::nextSample);
     r = new SequencePoolSampler(42);
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -58,6 +64,8 @@ public class SequenceSamplerByteTests {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceInsertionSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler();
     validateSamples(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerByteTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerByteTests.java
@@ -33,11 +33,15 @@ public class SequenceSamplerByteTests {
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleReservoir() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -45,11 +49,15 @@ public class SequenceSamplerByteTests {
   public void testSamplePool() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleInsertion() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -57,11 +65,15 @@ public class SequenceSamplerByteTests {
   public void testSampleCompositeP() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleReservoirP() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateWithP(r::nextSample);
   }
 
@@ -69,11 +81,15 @@ public class SequenceSamplerByteTests {
   public void testSamplePoolP() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleInsertionP() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateWithP(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerByteTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerByteTests.java
@@ -30,6 +30,16 @@ import org.junit.jupiter.api.*;
 public class SequenceSamplerByteTests {
 
   @Test
+  public void testDefaultSampler() {
+    SequenceSampler r = SequenceSampler.getDefault(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault(42);
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault();
+    validateSamples(r::nextSample);
+  }
+
+  @Test
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerCharTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerCharTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2019-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -35,6 +35,8 @@ public class SequenceSamplerCharTests {
     validateSamples(r::nextSample);
     r = new SequenceCompositeSampler(42);
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -42,6 +44,8 @@ public class SequenceSamplerCharTests {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceReservoirSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler();
     validateSamples(r::nextSample);
   }
 
@@ -51,6 +55,8 @@ public class SequenceSamplerCharTests {
     validateSamples(r::nextSample);
     r = new SequencePoolSampler(42);
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -58,6 +64,8 @@ public class SequenceSamplerCharTests {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceInsertionSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler();
     validateSamples(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerCharTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerCharTests.java
@@ -33,11 +33,15 @@ public class SequenceSamplerCharTests {
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleReservoir() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -45,11 +49,15 @@ public class SequenceSamplerCharTests {
   public void testSamplePool() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleInsertion() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -57,11 +65,15 @@ public class SequenceSamplerCharTests {
   public void testSampleCompositeP() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleReservoirP() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateWithP(r::nextSample);
   }
 
@@ -69,11 +81,15 @@ public class SequenceSamplerCharTests {
   public void testSamplePoolP() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleInsertionP() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateWithP(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerCharTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerCharTests.java
@@ -30,6 +30,16 @@ import org.junit.jupiter.api.*;
 public class SequenceSamplerCharTests {
 
   @Test
+  public void testDefaultSampler() {
+    SequenceSampler r = SequenceSampler.getDefault(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault(42);
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault();
+    validateSamples(r::nextSample);
+  }
+
+  @Test
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerDoubleTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerDoubleTests.java
@@ -30,6 +30,16 @@ import org.junit.jupiter.api.*;
 public class SequenceSamplerDoubleTests {
 
   @Test
+  public void testDefaultSampler() {
+    SequenceSampler r = SequenceSampler.getDefault(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault(42);
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault();
+    validateSamples(r::nextSample);
+  }
+
+  @Test
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerDoubleTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerDoubleTests.java
@@ -33,11 +33,15 @@ public class SequenceSamplerDoubleTests {
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleReservoir() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -45,11 +49,15 @@ public class SequenceSamplerDoubleTests {
   public void testSamplePool() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleInsertion() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -57,11 +65,15 @@ public class SequenceSamplerDoubleTests {
   public void testSampleCompositeP() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleReservoirP() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateWithP(r::nextSample);
   }
 
@@ -69,11 +81,15 @@ public class SequenceSamplerDoubleTests {
   public void testSamplePoolP() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleInsertionP() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateWithP(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerDoubleTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerDoubleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2019-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -35,6 +35,8 @@ public class SequenceSamplerDoubleTests {
     validateSamples(r::nextSample);
     r = new SequenceCompositeSampler(42);
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -42,6 +44,8 @@ public class SequenceSamplerDoubleTests {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceReservoirSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler();
     validateSamples(r::nextSample);
   }
 
@@ -51,6 +55,8 @@ public class SequenceSamplerDoubleTests {
     validateSamples(r::nextSample);
     r = new SequencePoolSampler(42);
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -58,6 +64,8 @@ public class SequenceSamplerDoubleTests {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceInsertionSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler();
     validateSamples(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerFloatTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerFloatTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2019-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -35,6 +35,8 @@ public class SequenceSamplerFloatTests {
     validateSamples(r::nextSample);
     r = new SequenceCompositeSampler(42);
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -42,6 +44,8 @@ public class SequenceSamplerFloatTests {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceReservoirSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler();
     validateSamples(r::nextSample);
   }
 
@@ -51,6 +55,8 @@ public class SequenceSamplerFloatTests {
     validateSamples(r::nextSample);
     r = new SequencePoolSampler(42);
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -58,6 +64,8 @@ public class SequenceSamplerFloatTests {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceInsertionSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler();
     validateSamples(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerFloatTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerFloatTests.java
@@ -30,6 +30,16 @@ import org.junit.jupiter.api.*;
 public class SequenceSamplerFloatTests {
 
   @Test
+  public void testDefaultSampler() {
+    SequenceSampler r = SequenceSampler.getDefault(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault(42);
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault();
+    validateSamples(r::nextSample);
+  }
+
+  @Test
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerFloatTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerFloatTests.java
@@ -33,11 +33,15 @@ public class SequenceSamplerFloatTests {
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleReservoir() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -45,11 +49,15 @@ public class SequenceSamplerFloatTests {
   public void testSamplePool() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleInsertion() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -57,11 +65,15 @@ public class SequenceSamplerFloatTests {
   public void testSampleCompositeP() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleReservoirP() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateWithP(r::nextSample);
   }
 
@@ -69,11 +81,15 @@ public class SequenceSamplerFloatTests {
   public void testSamplePoolP() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleInsertionP() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateWithP(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerIntTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerIntTests.java
@@ -30,6 +30,16 @@ import org.junit.jupiter.api.*;
 public class SequenceSamplerIntTests {
 
   @Test
+  public void testDefaultSampler() {
+    SequenceSampler r = SequenceSampler.getDefault(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault(42);
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault();
+    validateSamples(r::nextSample);
+  }
+
+  @Test
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerIntTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerIntTests.java
@@ -33,11 +33,15 @@ public class SequenceSamplerIntTests {
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleReservoir() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -45,11 +49,15 @@ public class SequenceSamplerIntTests {
   public void testSamplePool() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleInsertion() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -57,11 +65,15 @@ public class SequenceSamplerIntTests {
   public void testSampleCompositeP() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleReservoirP() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateWithP(r::nextSample);
   }
 
@@ -69,11 +81,15 @@ public class SequenceSamplerIntTests {
   public void testSamplePoolP() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleInsertionP() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateWithP(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerIntTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerIntTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2019-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -35,6 +35,8 @@ public class SequenceSamplerIntTests {
     validateSamples(r::nextSample);
     r = new SequenceCompositeSampler(42);
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -42,6 +44,8 @@ public class SequenceSamplerIntTests {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceReservoirSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler();
     validateSamples(r::nextSample);
   }
 
@@ -51,6 +55,8 @@ public class SequenceSamplerIntTests {
     validateSamples(r::nextSample);
     r = new SequencePoolSampler(42);
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -58,6 +64,8 @@ public class SequenceSamplerIntTests {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceInsertionSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler();
     validateSamples(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerLongTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerLongTests.java
@@ -33,11 +33,15 @@ public class SequenceSamplerLongTests {
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleReservoir() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -45,11 +49,15 @@ public class SequenceSamplerLongTests {
   public void testSamplePool() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleInsertion() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -57,11 +65,15 @@ public class SequenceSamplerLongTests {
   public void testSampleCompositeP() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleReservoirP() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateWithP(r::nextSample);
   }
 
@@ -69,11 +81,15 @@ public class SequenceSamplerLongTests {
   public void testSamplePoolP() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleInsertionP() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateWithP(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerLongTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerLongTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2019-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -35,6 +35,8 @@ public class SequenceSamplerLongTests {
     validateSamples(r::nextSample);
     r = new SequenceCompositeSampler(42);
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -42,6 +44,8 @@ public class SequenceSamplerLongTests {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceReservoirSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler();
     validateSamples(r::nextSample);
   }
 
@@ -51,6 +55,8 @@ public class SequenceSamplerLongTests {
     validateSamples(r::nextSample);
     r = new SequencePoolSampler(42);
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -58,6 +64,8 @@ public class SequenceSamplerLongTests {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceInsertionSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler();
     validateSamples(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerLongTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerLongTests.java
@@ -30,6 +30,16 @@ import org.junit.jupiter.api.*;
 public class SequenceSamplerLongTests {
 
   @Test
+  public void testDefaultSampler() {
+    SequenceSampler r = SequenceSampler.getDefault(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault(42);
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault();
+    validateSamples(r::nextSample);
+  }
+
+  @Test
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerObjectTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerObjectTests.java
@@ -33,11 +33,15 @@ public class SequenceSamplerObjectTests {
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleReservoir() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -45,11 +49,15 @@ public class SequenceSamplerObjectTests {
   public void testSamplePool() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleInsertion() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -57,11 +65,15 @@ public class SequenceSamplerObjectTests {
   public void testSampleCompositeP() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleReservoirP() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateWithP(r::nextSample);
   }
 
@@ -69,11 +81,15 @@ public class SequenceSamplerObjectTests {
   public void testSamplePoolP() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleInsertionP() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateWithP(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerObjectTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerObjectTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2019-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -35,6 +35,8 @@ public class SequenceSamplerObjectTests {
     validateSamples(r::nextSample);
     r = new SequenceCompositeSampler(42);
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -42,6 +44,8 @@ public class SequenceSamplerObjectTests {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceReservoirSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler();
     validateSamples(r::nextSample);
   }
 
@@ -51,6 +55,8 @@ public class SequenceSamplerObjectTests {
     validateSamples(r::nextSample);
     r = new SequencePoolSampler(42);
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -58,6 +64,8 @@ public class SequenceSamplerObjectTests {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceInsertionSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler();
     validateSamples(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerObjectTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerObjectTests.java
@@ -30,6 +30,16 @@ import org.junit.jupiter.api.*;
 public class SequenceSamplerObjectTests {
 
   @Test
+  public void testDefaultSampler() {
+    SequenceSampler r = SequenceSampler.getDefault(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault(42);
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault();
+    validateSamples(r::nextSample);
+  }
+
+  @Test
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerShortTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerShortTests.java
@@ -30,6 +30,16 @@ import org.junit.jupiter.api.*;
 public class SequenceSamplerShortTests {
 
   @Test
+  public void testDefaultSampler() {
+    SequenceSampler r = SequenceSampler.getDefault(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault(42);
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault();
+    validateSamples(r::nextSample);
+  }
+
+  @Test
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerShortTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerShortTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2019-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -35,6 +35,8 @@ public class SequenceSamplerShortTests {
     validateSamples(r::nextSample);
     r = new SequenceCompositeSampler(42);
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -42,6 +44,8 @@ public class SequenceSamplerShortTests {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceReservoirSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler();
     validateSamples(r::nextSample);
   }
 
@@ -51,6 +55,8 @@ public class SequenceSamplerShortTests {
     validateSamples(r::nextSample);
     r = new SequencePoolSampler(42);
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -58,6 +64,8 @@ public class SequenceSamplerShortTests {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceInsertionSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler();
     validateSamples(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerShortTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerShortTests.java
@@ -33,11 +33,15 @@ public class SequenceSamplerShortTests {
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleReservoir() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -45,11 +49,15 @@ public class SequenceSamplerShortTests {
   public void testSamplePool() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleInsertion() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -57,11 +65,15 @@ public class SequenceSamplerShortTests {
   public void testSampleCompositeP() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleReservoirP() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateWithP(r::nextSample);
   }
 
@@ -69,11 +81,15 @@ public class SequenceSamplerShortTests {
   public void testSamplePoolP() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleInsertionP() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateWithP(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerStringTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerStringTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2019-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -35,6 +35,8 @@ public class SequenceSamplerStringTests {
     validateSamples(r::nextSample);
     r = new SequenceCompositeSampler(42);
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -42,6 +44,8 @@ public class SequenceSamplerStringTests {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceReservoirSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler();
     validateSamples(r::nextSample);
   }
 
@@ -51,6 +55,8 @@ public class SequenceSamplerStringTests {
     validateSamples(r::nextSample);
     r = new SequencePoolSampler(42);
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler();
+    validateSamples(r::nextSample);
   }
 
   @Test
@@ -58,6 +64,8 @@ public class SequenceSamplerStringTests {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
     r = new SequenceInsertionSampler(42);
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler();
     validateSamples(r::nextSample);
   }
 

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerStringTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerStringTests.java
@@ -30,6 +30,16 @@ import org.junit.jupiter.api.*;
 public class SequenceSamplerStringTests {
 
   @Test
+  public void testDefaultSampler() {
+    SequenceSampler r = SequenceSampler.getDefault(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault(42);
+    validateSamples(r::nextSample);
+    r = SequenceSampler.getDefault();
+    validateSamples(r::nextSample);
+  }
+
+  @Test
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);

--- a/src/test/java/org/cicirello/sequences/SequenceSamplerStringTests.java
+++ b/src/test/java/org/cicirello/sequences/SequenceSamplerStringTests.java
@@ -33,11 +33,15 @@ public class SequenceSamplerStringTests {
   public void testSampleComposite() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleReservoir() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -45,11 +49,15 @@ public class SequenceSamplerStringTests {
   public void testSamplePool() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateSamples(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateSamples(r::nextSample);
   }
 
   @Test
   public void testSampleInsertion() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateSamples(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateSamples(r::nextSample);
   }
 
@@ -57,11 +65,15 @@ public class SequenceSamplerStringTests {
   public void testSampleCompositeP() {
     SequenceCompositeSampler r = new SequenceCompositeSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequenceCompositeSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleReservoirP() {
     SequenceReservoirSampler r = new SequenceReservoirSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceReservoirSampler(42);
     validateWithP(r::nextSample);
   }
 
@@ -69,11 +81,15 @@ public class SequenceSamplerStringTests {
   public void testSamplePoolP() {
     SequencePoolSampler r = new SequencePoolSampler(new SplittableRandom(42));
     validateWithP(r::nextSample);
+    r = new SequencePoolSampler(42);
+    validateWithP(r::nextSample);
   }
 
   @Test
   public void testSampleInsertionP() {
     SequenceInsertionSampler r = new SequenceInsertionSampler(new SplittableRandom(42));
+    validateWithP(r::nextSample);
+    r = new SequenceInsertionSampler(42);
     validateWithP(r::nextSample);
   }
 


### PR DESCRIPTION
## Summary
Modified SequenceSampler implementations to:
* Fix method implementations with probability p of sampling an element fixed to always use specified randomness source (previously incorrectly used default randomness source on some calls).
* Other improvements related to changes in dependency rho-mu v3.1.1
* Removed default implementations of `nextSample` methods of SequenceSampler interface for cases where probability p of selecting an element is specified (these now implemented in the specific classes to properly use source of randomness for all calls to random number generators (cause of previous bug). This is a __breaking change__ since it is possible someone may have implemented this interface, while relying on those default methods. This is __scheduled for the next major release__. 
* Seeded constructors added to SequenceReservoirSampler, SequencePoolSampler, SequenceInsertionSampler, SequenceCompositeSampler.
* Default constructors added to SequenceReservoirSampler, SequencePoolSampler, SequenceInsertionSampler, SequenceCompositeSampler.
* Added SequenceSampler.getDefault() method for creating an instance of the default implementation of SequenceSampler.
* Added SequenceSampler.getDefault(RandomGenerator) method for creating an instance of the default implementation of SequenceSampler from a given source of randomness.
* Added SequenceSampler.getDefault(seed) method for creating an instance of the default implementation of SequenceSampler, specifying a seed for the random number generator.

## Closing Issues
Closes #349 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
