### PR TITLE
Prevent potential finalizer attack in EditDistance constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2024-04-09
+## [Unreleased] - 2024-05-14
 
 **Breaking Changes**: Due to breaking changes, the next release will be a major release (see the Removed section below for details). Timing of that major release will likely be in the Fall of 2023 to coincide with the planned transition to Java 21 upon its release.
 
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 * Bump rho-mu from 3.1.0 to 3.2.0
-* Bump org.cicirello:core from 2.5.0 to 2.6.0
+* Bump org.cicirello:core from 2.5.0 to 2.7.0
 
 ### CI/CD
 * Integrated SpotBugs static analysis into build process.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed potential integer overflow error in ReinsertionDistance
 * Fixed transient fields in Permutation that shouldn't be transient
 * Classes implementing SequenceSampler interface: methods with probability p of sampling an element fixed to always use specified randomness source (previously incorrectly used default randomness source on some calls).
+* Fixed potential finalizer vulnerability in org.cicirello.sequences.distance.EditDistance, detected by SpotBugs analysis. 
 
 ### Dependencies
 * Bump rho-mu from 3.1.0 to 3.2.0

--- a/src/main/java/org/cicirello/permutations/distance/InterchangeDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/InterchangeDistance.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools - A Java library for computation on permutations.
- * Copyright 2005-2022 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2024 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can
  * redistribute it and/or modify it under the terms of the GNU
@@ -28,7 +28,7 @@ import org.cicirello.permutations.Permutation;
  *
  * <p>Interchange distance is computed efficiently by counting the number of permutation cycles
  * between the permutations. A permutation cycle of length k is transformed into k fixed points with
- * k − 1 swaps (a fixed point is a cycle of length 1).
+ * k - 1 swaps (a fixed point is a cycle of length 1).
  *
  * <p>Runtime: O(n), where n is the permutation length.
  *

--- a/src/main/java/org/cicirello/permutations/distance/KendallTauDistance.java
+++ b/src/main/java/org/cicirello/permutations/distance/KendallTauDistance.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools - A Java library for computation on permutations.
- * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2024 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * JavaPermutationTools is free software: you can
  * redistribute it and/or modify it under the terms of the GNU
@@ -43,7 +43,7 @@ import org.cicirello.permutations.Permutation;
  * modified version of mergesort to count the inversions.
  *
  * <p>Kendall Tau distance originally described in:<br>
- * M. G. Kendall, "A new measure of rank correlation," Biometrika, vol. 30, no. 1/2, pp. 81–93, June
+ * M. G. Kendall, "A new measure of rank correlation," Biometrika, vol. 30, no. 1/2, pp. 81-93, June
  * 1938.
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a

--- a/src/main/java/org/cicirello/sequences/distance/EditDistance.java
+++ b/src/main/java/org/cicirello/sequences/distance/EditDistance.java
@@ -1,6 +1,6 @@
 /*
  * JavaPermutationTools: A Java library for computation on permutations and sequences
- * Copyright 2005-2023 Vincent A. Cicirello, <https://www.cicirello.org/>.
+ * Copyright 2005-2024 Vincent A. Cicirello, <https://www.cicirello.org/>.
  *
  * This file is part of JavaPermutationTools (https://jpt.cicirello.org/).
  *
@@ -71,12 +71,31 @@ public class EditDistance implements SequenceDistanceMeasurer {
    * @throws IllegalArgumentException if any of the costs are negative.
    */
   public EditDistance(int insertCost, int deleteCost, int changeCost) {
-    if (insertCost < 0 || deleteCost < 0 || changeCost < 0) {
-      throw new IllegalArgumentException("Costs must be non-negative.");
-    }
+    this(insertCost, deleteCost, changeCost, validateCosts(insertCost, deleteCost, changeCost));
+  }
+
+  /*
+   * Prevent finalizer attack with private constructor, and validation/exception occuring
+   * in the static validateCosts method. This should prevent a partially instantiated object
+   * if exception is thrown. Note that secure will only ever be true, as an exception will
+   * be thrown before here if they are not.
+   */
+  private EditDistance(int insertCost, int deleteCost, int changeCost, boolean secure) {
     this.insertCost = insertCost;
     this.deleteCost = deleteCost;
     this.changeCost = changeCost;
+  }
+
+  /*
+   * Prevent finalizer attack with private constructor, and validation/exception occuring
+   * in the static validateCosts method. This should prevent a partially instantiated object
+   * if exception is thrown.
+   */
+  private static boolean validateCosts(int insertCost, int deleteCost, int changeCost) {
+    if (insertCost < 0 || deleteCost < 0 || changeCost < 0) {
+      throw new IllegalArgumentException("Costs must be non-negative.");
+    }
+    return true;
   }
 
   @Override

--- a/src/main/java/org/cicirello/sequences/distance/EditDistance.java
+++ b/src/main/java/org/cicirello/sequences/distance/EditDistance.java
@@ -51,7 +51,7 @@ import java.util.List;
  *
  * <p>Wagner and Fischer's String Edit Distance was introduced in:<br>
  * R. A. Wagner and M. J. Fischer, "The string-to-string correction problem," Journal of the ACM,
- * vol. 21, no. 1, pp. 168–173, January 1974.
+ * vol. 21, no. 1, pp. 168-173, January 1974.
  *
  * @author <a href=https://www.cicirello.org/ target=_top>Vincent A. Cicirello</a>, <a
  *     href=https://www.cicirello.org/ target=_top>https://www.cicirello.org/</a>


### PR DESCRIPTION
## Summary
Fixed potential finalizer vulnerability in org.cicirello.sequences.distance.EditDistance, detected by SpotBugs analysis. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
