### PR TITLE
Change minimum supported Java version to 21 (resolves #345)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/setup-java@v5
       with:
         distribution: 'adopt'
-        java-version: '17'
+        java-version: '21'
 
     - name: Build with Maven
       run: mvn -B package -Pcoverage

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/setup-java@v5
       with:
         distribution: 'adopt'
-        java-version: '17'
+        java-version: '21'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/setup-java@v5
       with:
         distribution: 'adopt'
-        java-version: '17'
+        java-version: '21'
 
     - name: Build docs with Maven
       run: mvn compile javadoc:javadoc

--- a/.github/workflows/manual-deploy-github-only.yml
+++ b/.github/workflows/manual-deploy-github-only.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/setup-java@v5
       with:
         distribution: 'adopt'
-        java-version: '17'
+        java-version: '21'
         server-id: github
 
     - name: Build with Maven

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/setup-java@v5
       with:
         distribution: 'adopt'
-        java-version: '17'
+        java-version: '21'
         server-id: github
         
     - name: Build with Maven

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-java@v5
       with:
         distribution: 'adopt'
-        java-version: '17'
+        java-version: '21'
         server-id: central 
         server-username: MAVEN_USERNAME
         server-password: MAVEN_CENTRAL_TOKEN
@@ -47,7 +47,7 @@ jobs:
       uses: actions/setup-java@v5
       with:
         distribution: 'adopt'
-        java-version: '17'
+        java-version: '21'
         server-id: github 
 
     - name: Publish to GitHub Packages Apache Maven

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
   
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.release>17</maven.compiler.release>
+		<maven.compiler.release>21</maven.compiler.release>
 	</properties>
   
 	<build>
@@ -229,7 +229,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.15.0</version>
 				<configuration>
-					<release>17</release>
+					<release>21</release>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Resolves #345.

Raises the minimum supported Java version from 17 to **21**:

- `pom.xml`: `maven.compiler.release` (and the compiler plugin's `<release>`) `17` → `21`.
- CI: `java-version` `17` → `21` across all setup-java steps (build, codeql-analysis, docs, both manual-deploy workflows, and both maven-publish jobs).

## Verification
Built on Temurin 21 with `mvn -B verify` (a superset of CI's `mvn -B package -Pcoverage`): **BUILD SUCCESS — 367 tests, 0 failures, 0 skipped**, identical to the JDK 17 baseline. SpotBugs and JaCoCo both pass on 21.

🤖 Migrated with the [bump-java-version](https://github.com/vasiliy-mikhailov/bump-java-version-skill) skill.
